### PR TITLE
Automatically use the specified version of yarn after installing

### DIFF
--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -47,6 +47,9 @@ yvm_() {
         curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash
     else
         yvm_call_node_script $@
+        if [ "${command}" = "install" ]; then
+            yvm_use $2
+        fi
     fi
 }
 

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -14,16 +14,20 @@ save_last_used_yarn_version() {
         return
     fi
     
-    if ! grep -q "LAST_USED_YARN_VERSION" ~/.zshrc; then
-        sed -i '' 's/.*YVM_DIR.*/export LAST_USED_YARN_VERSION='"${yarn_version}"'\'$'\n&/g' ~/.zshrc
-    else
-        sed -i '' "s/LAST_USED_YARN_VERSION.*/LAST_USED_YARN_VERSION=${yarn_version}/" ~/.zshrc
+    if [ -e ~/.zshrc ]; then
+        if ! grep -q "LAST_USED_YARN_VERSION" ~/.zshrc; then
+            sed -i '' 's/.*YVM_DIR.*/export LAST_USED_YARN_VERSION='"${yarn_version}"'\'$'\n&/g' ~/.zshrc
+        else
+            sed -i '' "s/LAST_USED_YARN_VERSION.*/LAST_USED_YARN_VERSION=${yarn_version}/" ~/.zshrc
+        fi
     fi
 
-    if ! grep -q "LAST_USED_YARN_VERSION" ~/.bash_profile; then
-        sed -i '' 's/.*YVM_DIR.*/export LAST_USED_YARN_VERSION='"${yarn_version}"'\'$'\n&/g' ~/.bash_profile
-    else
-        sed -i '' "s/LAST_USED_YARN_VERSION.*/LAST_USED_YARN_VERSION=${yarn_version}/" ~/.bash_profile
+    if [ -e ~/.bash_profile ]; then
+        if ! grep -q "LAST_USED_YARN_VERSION" ~/.bash_profile; then
+            sed -i '' 's/.*YVM_DIR.*/export LAST_USED_YARN_VERSION='"${yarn_version}"'\'$'\n&/g' ~/.bash_profile
+        else
+            sed -i '' "s/LAST_USED_YARN_VERSION.*/LAST_USED_YARN_VERSION=${yarn_version}/" ~/.bash_profile
+        fi
     fi
 }
 

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -2,16 +2,43 @@
 
 command=$1
 YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}
+export_yvm_dir_string="export YVM_DIR=${YVM_DIR}"
+
+save_last_used_yarn_version() {
+    yarn_version="${1}"
+    if [ -z "$yarn_version" ]; then
+        yarn_version="$(yarn --version)"
+    fi
+
+    if [ -z "$yarn_version" ]; then
+        return
+    fi
+    
+    if ! grep -q "LAST_USED_YARN_VERSION" ~/.zshrc; then
+        sed -i '' 's/.*YVM_DIR.*/export LAST_USED_YARN_VERSION='"${yarn_version}"'\'$'\n&/g' ~/.zshrc
+    else
+        sed -i '' "s/LAST_USED_YARN_VERSION.*/LAST_USED_YARN_VERSION=${yarn_version}/" ~/.zshrc
+    fi
+
+    if ! grep -q "LAST_USED_YARN_VERSION" ~/.bash_profile; then
+        sed -i '' 's/.*YVM_DIR.*/export LAST_USED_YARN_VERSION='"${yarn_version}"'\'$'\n&/g' ~/.bash_profile
+    else
+        sed -i '' "s/LAST_USED_YARN_VERSION.*/LAST_USED_YARN_VERSION=${yarn_version}/" ~/.bash_profile
+    fi
+}
 
 yvm_use() {
     local PROVIDED_VERSION=${1}
+    echo ${PROVIDED_VERSION}
     NEW_PATH=$(yvm_call_node_script get-new-path ${PROVIDED_VERSION})
+    echo ${NEW_PATH}
     if [ -z "${NEW_PATH}" ]; then
         yvm_err "Could not get new path from yvm"
     else
         PATH=${NEW_PATH}
         yvm_echo "Now using yarn version $(yarn --version)"
     fi
+    save_last_used_yarn_version ${1}
 }
 
 yvm_echo() {
@@ -57,6 +84,12 @@ if [ ${interactive} = 1 ]; then
     yvm() {
         yvm_ 'function' $@
     }
+    last_used_yarn="${LAST_USED_YARN_VERSION:-}"
+    if [ -z "$last_used_yarn" ]; then
+        yvm_echo "No default yarn version set. Use yvm install <version> or yvm use <version> to fix this"
+    else
+        yvm_use ${last_used_yarn}
+    fi
 else
     yvm_ 'script' $@
 fi


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- yvm will not automatically use the yarn version specified after installing using `yvm install [version]`


## DevQA
- Run `yvm install [version of your choice]`
- It should set that same version as the current yarn version. 
- Can confirm using `yvm which`

