### PR TITLE
feat: shim yarn commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <!-- OVERVIEW-DOCS:START -->
 
-Pesky yarn versions got you down? Automatically and easilly manage those versions.
+Pesky yarn versions got you down? Automatically and easily manage those versions.
 
 YVM will automatically use the correct yarn version when you run any yarn commands in any folder with a `package.json`, `.yvmrc` or any other [supported configuration](https://yvm.js.org/docs/faq#declare-yvm-version-in-a-configuration-file-where-can-i-place-my-version-number) file. Otherwise, it will use you a globally set version of yarn.
 
@@ -84,13 +84,19 @@ yvm update-self
 
 ## Usage
 
-### Automatic magic
+### Automagic
 
-Run any yarn command and watch it magically use the correct version of yarn
+Run any yarn command and watch it automagically use the correct version of yarn.
+
+Yarn is shimmed to use the default version or the version defined your current directory [config file](#configuration-file).
+
+```sh
+yarn --version
+```
 
 ### Basic
 
-To download and install a version of yarn, run:
+To download and install a specific version of yarn, run:
 
 ```bash
 yvm install <version>
@@ -116,6 +122,8 @@ Switch the current yarn versions:
 yvm use <version>
 yarn --version
 ```
+
+**NOTE**: The above disables [yarn shimming](#automagic) until a new shell is loaded.
 
 Control version aliasing:
 

--- a/scripts/install-watch.sh
+++ b/scripts/install-watch.sh
@@ -30,6 +30,7 @@ restore_file() {
 save_and_link_file "yvm.sh"
 save_and_link_file "yvm.js"
 save_and_link_file "yvm.fish"
+save_and_link_file "shim/yarn"
 
 # Save and Link Node Modules
 echo "Saving+Linking node_modules"
@@ -49,6 +50,7 @@ trap int_trap INT
 restore_file "yvm.sh"
 restore_file "yvm.js"
 restore_file "yvm.fish"
+restore_file "shim/yarn"
 
 # Restore Node Modules
 rm "${HOME}/.yvm/node_modules"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -191,13 +191,15 @@ async function removeFile(filePath) {
 }
 
 async function cleanYvmDir(yvmPath) {
-    const removing = []
-    for (const filePath of fs.readdirSync(yvmPath)) {
-        if (!filePath.endsWith('versions')) {
-            removing.push(removeFile(filePath))
-        }
-    }
-    await Promise.all(removing)
+    const filesNotToRemove = new Set(['versions'])
+    const filesToRemove = fs
+        .readdirSync(yvmPath)
+        .filter(f => !filesNotToRemove.has(f))
+    await Promise.all(
+        filesToRemove.map(file =>
+            removeFile(path.join(yvmPath, file)).catch(log),
+        ),
+    )
 }
 
 async function unzipFile(filePath, yvmPath) {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -212,6 +212,10 @@ async function saveVersion(versionTag, yvmPath) {
 }
 
 async function ensureScriptExecutable(filePath) {
+    if (!fs.existsSync(filePath)) {
+        log(`${filePath} does not exist`)
+        return
+    }
     execSync(`chmod +x ${filePath}`)
 }
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -28,6 +28,8 @@ function preflightCheck(...dependencies) {
     log('All dependencies satisfied.')
 }
 
+const zipFile = 'yvm.zip'
+
 function getConfig() {
     const home = process.env.HOME || os.homedir()
     const useLocal = process.env.USE_LOCAL || false
@@ -38,7 +40,7 @@ function getConfig() {
             yvm: yvmDir,
             yvmSh: path.join(yvmDir, 'yvm.sh'),
             yarnShim: path.join(yvmDir, 'shim', 'yarn'),
-            zip: path.join(useLocal ? 'artifacts' : yvmDir, 'yvm.zip'),
+            zip: path.join(useLocal ? 'artifacts' : yvmDir, zipFile),
         },
         releaseApiUrl: 'https://d236jo9e8rrdox.cloudfront.net/yvm-releases',
         releasesApiUrl: 'https://api.github.com/repos/tophat/yvm/releases',
@@ -191,7 +193,7 @@ async function removeFile(filePath) {
 }
 
 async function cleanYvmDir(yvmPath) {
-    const filesNotToRemove = new Set(['versions', 'yvm.zip'])
+    const filesNotToRemove = new Set(['versions', zipFile])
     const filesToRemove = fs
         .readdirSync(yvmPath)
         .filter(f => !filesNotToRemove.has(f))
@@ -206,9 +208,9 @@ async function unzipFile(filePath, yvmPath) {
     execSync(`unzip -o -q ${filePath} -d ${yvmPath}`)
 }
 
-async function saveVersion(versionTag, yvmPath) {
+async function saveVersion(version, yvmPath) {
     const filePath = path.join(yvmPath, '.version')
-    fs.writeFileSync(filePath, `{ "version": "${versionTag}" }`)
+    fs.writeFileSync(filePath, JSON.stringify({ version }))
 }
 
 async function ensureScriptExecutable(filePath) {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -193,7 +193,7 @@ async function removeFile(filePath) {
 async function cleanYvmDir(yvmPath) {
     const removing = []
     for (const filePath of fs.readdirSync(yvmPath)) {
-        if (!filePath.endsWith('version')) {
+        if (!filePath.endsWith('versions')) {
             removing.push(removeFile(filePath))
         }
     }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -191,7 +191,7 @@ async function removeFile(filePath) {
 }
 
 async function cleanYvmDir(yvmPath) {
-    const filesNotToRemove = new Set(['versions'])
+    const filesNotToRemove = new Set(['versions', 'yvm.zip'])
     const filesToRemove = fs
         .readdirSync(yvmPath)
         .filter(f => !filesNotToRemove.has(f))

--- a/scripts/tests/install.test.js
+++ b/scripts/tests/install.test.js
@@ -29,7 +29,7 @@ describe('install yvm', () => {
     const envUseLocal = mockProp(process.env, 'USE_LOCAL')
     const envInstallVersion = mockProp(process.env, 'INSTALL_VERSION')
     jest.spyOn(os, 'homedir').mockReturnValue(mockHomeValue)
-
+    const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish']
     const expectedConfigObject = ({ homePath, tagName = null, useLocal }) => ({
         paths: {
             home: homePath,
@@ -148,7 +148,6 @@ describe('install yvm', () => {
                     expect.stringContaining(output),
                 ),
             )
-            const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish']
             installFiles.forEach(file => {
                 const filePath = `${yvmHome}/${file}`
                 expect(fs.pathExistsSync(filePath)).toBe(true)
@@ -242,7 +241,6 @@ describe('install yvm', () => {
                     expect.stringContaining(output),
                 ),
             )
-            const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish']
             installFiles.forEach(file => {
                 const filePath = `${yvmHome}/${file}`
                 expect(fs.pathExistsSync(filePath)).toBe(true)
@@ -291,7 +289,6 @@ describe('install yvm', () => {
                     expect.stringContaining(output),
                 ),
             )
-            const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish']
             installFiles.forEach(file => {
                 const filePath = `${yvmHome}/${file}`
                 expect(fs.pathExistsSync(filePath)).toBe(true)
@@ -338,7 +335,6 @@ describe('install yvm', () => {
             // should not have created version tag
             expect(fs.pathExistsSync(`${yvmHome}/.version`)).toBe(false)
             // should not have extracted files
-            const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish']
             installFiles.forEach(file => {
                 const filePath = `${yvmHome}/${file}`
                 expect(fs.pathExistsSync(filePath)).toBe(false)

--- a/scripts/tests/install.test.js
+++ b/scripts/tests/install.test.js
@@ -29,7 +29,7 @@ describe('install yvm', () => {
     const envUseLocal = mockProp(process.env, 'USE_LOCAL')
     const envInstallVersion = mockProp(process.env, 'INSTALL_VERSION')
     jest.spyOn(os, 'homedir').mockReturnValue(mockHomeValue)
-    const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish']
+    const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish', 'shim/yarn']
     const expectedConfigObject = ({ homePath, tagName = null, useLocal }) => ({
         paths: {
             home: homePath,
@@ -241,6 +241,7 @@ describe('install yvm', () => {
                     expect.stringContaining(output),
                 ),
             )
+            const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish']
             installFiles.forEach(file => {
                 const filePath = `${yvmHome}/${file}`
                 expect(fs.pathExistsSync(filePath)).toBe(true)
@@ -289,6 +290,7 @@ describe('install yvm', () => {
                     expect.stringContaining(output),
                 ),
             )
+            const installFiles = ['yvm.sh', 'yvm.js', 'yvm.fish']
             installFiles.forEach(file => {
                 const filePath = `${yvmHome}/${file}`
                 expect(fs.pathExistsSync(filePath)).toBe(true)

--- a/src/shim/yarn.js
+++ b/src/shim/yarn.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const [bin, file, ...args] = process.argv
+process.argv = [bin, file, 'exec', ...args]
+require('../yvm')

--- a/src/yvm.fish
+++ b/src/yvm.fish
@@ -40,11 +40,7 @@ function yvm
             yvm_err "%s\n" "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your fish config file"
             exit 1
         end
-
-        set -U DEFAULT_YARN_VERSION (yvm_call_node_script get-default-version 2>/dev/null)
-        if [ "x" != "x$DEFAULT_YARN_VERSION" ]
-            yvm_use > /dev/null
-        end
+        set -U fish_user_paths "$YVM_DIR/shim" $fish_user_paths
     end
 
     if [ "$command" = "use" ]

--- a/src/yvm.fish
+++ b/src/yvm.fish
@@ -15,7 +15,7 @@ function yvm
         if [ -z "$NEW_FISH_USER_PATHS" ]
             yvm_err "Could not get new path from yvm"
         else
-            set -U fish_user_paths $NEW_FISH_USER_PATHS
+            set -U fish_user_paths (string split ' ' -- $NEW_FISH_USER_PATHS)
             set -l new_version (yarn --version)
             yvm_echo "Now using yarn version $new_version"
         end

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -33,10 +33,7 @@ yvm() {
             yvm_err "YVM Could not find node executable."
             yvm_err "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bashrc"
         fi
-        DEFAULT_YARN_VERSION=$(yvm_call_node_script get-default-version 2>/dev/null)
-        if [ "x" != "x${DEFAULT_YARN_VERSION}" ]; then
-            yvm_use > /dev/null
-        fi
+        export PATH="${YVM_DIR}/shim":$PATH
     }
 
     if [ "${command}" = "use" ]; then

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -18,7 +18,13 @@ module.exports = {
         path: outputPath,
     },
     target: 'node',
-    plugins: [new CopyPlugin(['src/yvm.sh', 'src/yvm.fish'])],
+    plugins: [
+        new CopyPlugin([
+            'src/yvm.sh',
+            'src/yvm.fish',
+            { from: 'src/shim/yarn.js', to: './shim/yarn', toType: 'file' },
+        ]),
+    ],
     module: {
         rules: [
             {


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
Should resolve #136. All yarn commands will now be shimmed. YVM will look for a `.yvmrc` file to see which version of yarn should be used. If none are found, it will used the last globally set default version of yarn.


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `make install`
- Open a new terminal session. `echo $PATH`. You should see the shim directory at the front of your path.

### DevQA Steps
- Run any yarn command. If you do not have a default yarn version set, this will be executed using the `default` `stable` version.
- Switch into any folder with a .yvmrc file with a yarn version that is not installed. Run a yarn command. This will download and install the yarn version before running the command.


