### PR TITLE
Show yarn version number to which command

### DIFF
--- a/src/commands/which.js
+++ b/src/commands/which.js
@@ -3,7 +3,7 @@ const { getRcFileVersion } = require('../util/version')
 const log = require('../util/log')
 const { yvmPath, versionRootPath } = require('../util/utils')
 
-const whichCommand = inputPath => {
+const whichCommand = (inputPath, testPath = '') => {
     if (!shell.which('yarn')) {
         shell.echo('Sorry, yarn in NOT installed.')
         shell.exit(1)
@@ -13,11 +13,13 @@ const whichCommand = inputPath => {
         return 1
     }
 
+    const yvmPathToUse = testPath ? testPath : yvmPath
+
     let foundVersion = false
 
     const pathVariables = envPath.split(':')
     pathVariables.forEach(element => {
-        if (element.startsWith(versionRootPath(yvmPath))) {
+        if (element.startsWith(versionRootPath(yvmPathToUse))) {
             const versionRegex = /(v\d+\.?\d*\.?\d*)/gm
             const matchedVersion = element.match(versionRegex)
             log.info(

--- a/src/commands/which.js
+++ b/src/commands/which.js
@@ -26,12 +26,15 @@ const whichCommand = inputPath => {
 
             const pathVersion = matchedVersion.toString().replace(/v/g, '')
             const rcVersion = getRcFileVersion()
+            log(`Currently on yarn version ${pathVersion}`)
             if (rcVersion !== null) {
                 if (pathVersion === rcVersion) {
-                    log('your RC version matches your PATH version, good job!')
+                    log(
+                        'Your .yvmrc version matches your PATH version, good job!',
+                    )
                 } else {
                     log(
-                        `your RC version: ${rcVersion} and PATH version: ${pathVersion} don't match :(`,
+                        `Your .yvmrc version: ${rcVersion} and PATH version: ${pathVersion} don't match :(`,
                     )
                 }
             }

--- a/test/commands/which.test.js
+++ b/test/commands/which.test.js
@@ -1,8 +1,20 @@
+const fs = require('fs')
 const which = require('../../src/commands/which')
 
 describe('yvm which command', () => {
-    it('fails to find yarn version', () => {
+    it('fails to find yarn version if none installed', () => {
         const path = '/Users/tophat/.nvm/versions/node/v6.11.5/bin:'
         expect(which(path)).toBe(2)
+    })
+    it('Succeeds if yvm version matches .yvmrc', () => {
+        const version = fs.readFileSync('.yvmrc', 'utf8')
+        const path = `/Users/tophat/.yvm/versions/v${version}/bin:`
+        const testPath = '/Users/tophat/.yvm'
+        expect(which(path, testPath)).toBe(0)
+    })
+    it('Succeeds if yvm version does not match .yvmrc', () => {
+        const path = '/Users/tophat/.yvm/versions/v0.0.0/bin:'
+        const testPath = '/Users/tophat/.yvm'
+        expect(which(path, testPath)).toBe(0)
     })
 })


### PR DESCRIPTION
## Description
`yvm which` does not actually show what version of yarn you are currently using. This fixes that.



## DevQA

### DevQA Prep
- Make sure some version of yarn is enabled.

### DevQA Steps
- Run `yvm which`. It should display the version of yarn you are currently using.


