### PR TITLE
fix: double help/usage output when calling yvm

### DIFF
--- a/src/yvm.js
+++ b/src/yvm.js
@@ -98,10 +98,5 @@ argParser
   .description('Show help text')
   .action(() => argParser.outputHelp());
 
-const noParams = !process.argv.slice(2).length;
-if (noParams) {
-  argParser.outputHelp();
-}
-
 /* eslint-enable global-require,prettier/prettier */
 argParser.parse(process.argv)


### PR DESCRIPTION
## Description
Addresses #183. 

`yvm` should output help once
`yvm help` should continue to work