### PR TITLE
feat: add global yarn version, remove concept of last used version

### DIFF
--- a/src/util/version.js
+++ b/src/util/version.js
@@ -15,7 +15,7 @@ function getDefaultVersion(yvmPath = defaultYvmPath) {
         const versionJSON = JSON.parse(versionJSONString)
         const version = versionJSON.defaultVersion
         if (!version) {
-            throw new Error(`Version JSON exists but contains no key 'version'`)
+            throw new Error(`Version JSON exists but contains no key 'defaultVersion'`)
         }
         return version
     } catch (e) {

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -1,8 +1,43 @@
+const fs = require('fs')
+const path = require('path')
 const cosmiconfig = require('cosmiconfig')
 const log = require('./log')
+const { yvmPath: defaultYvmPath } = require('./utils')
 
 function isValidVersionString(version) {
-    return /\d+\.\d+\.\d+/.test(version)
+    return /^\d+\.\d+\.\d+$/.test(version)
+}
+
+function getDefaultVersion(yvmPath = defaultYvmPath) {
+    const versionStoragePath = path.join(yvmPath, '.default-version')
+    try {
+        const versionJSONString = fs.readFileSync(versionStoragePath, 'utf8')
+        const versionJSON = JSON.parse(versionJSONString)
+        const version = versionJSON.defaultVersion
+        if (!version) {
+            throw new Error(`Version JSON exists but contains no key 'version'`)
+        }
+        return version
+    } catch (e) {
+        log.info('Unable to determine default version')
+        log.info(e)
+        return undefined
+    }
+}
+
+function setDefaultVersion({ version, yvmPath = defaultYvmPath }) {
+    const versionStoragePath = path.join(yvmPath, '.default-version')
+
+    const jsonObject = { defaultVersion: version }
+    const content = JSON.stringify(jsonObject)
+    try {
+        fs.writeFileSync(versionStoragePath, content)
+        return true
+    } catch (e) {
+        log('Unable to set default version')
+        log(e)
+        return false
+    }
 }
 
 function getRcFileVersion() {
@@ -13,17 +48,6 @@ function getRcFileVersion() {
     }
     log.info(`Found config ${result.filepath}`)
     return result.config
-}
-
-function validateVersionString(versionString) {
-    if (versionString === null) {
-        throw new Error(
-            `No yarn version supplied!\nTry adding a config file (.yvmrc) or specify your version in the command like this: "yvm install 1.7.0"`,
-        )
-    }
-    if (!isValidVersionString(versionString) && versionString !== null) {
-        throw new Error(`Invalid yarn version supplied: ${versionString}`)
-    }
 }
 
 // eslint-disable-next-line consistent-return
@@ -38,10 +62,30 @@ const getSplitVersionAndArgs = (maybeVersionArg, ...rest) => {
     rest.unshift(maybeVersionArg)
 
     try {
-        const version = getRcFileVersion()
-        validateVersionString(version)
-        log.info(`Using yarn version: ${version}`)
-        return [version, rest]
+        const rcVersion = getRcFileVersion()
+        let versionToUse
+        if (rcVersion) {
+            if (!isValidVersionString(rcVersion)) {
+                throw new Error(
+                    `Invalid yarn version found in .yarnrc: ${rcVersion}`,
+                )
+            }
+            versionToUse = rcVersion
+        } else {
+            versionToUse = getDefaultVersion()
+        }
+
+        if (!versionToUse) {
+            throw new Error(
+                `No yarn version supplied!
+Try:
+    Setting a global default version (yvm set-default 1.9.2)
+    Adding .yvmrc file in this directory or a parent directory
+    Specify your version in the command.`,
+            )
+        }
+        log.info(`Using yarn version: ${versionToUse}`)
+        return [versionToUse, rest]
     } catch (e) {
         log(e.message)
         process.exit(1)
@@ -51,4 +95,7 @@ const getSplitVersionAndArgs = (maybeVersionArg, ...rest) => {
 module.exports = {
     getRcFileVersion,
     getSplitVersionAndArgs,
+    getDefaultVersion,
+    setDefaultVersion,
+    isValidVersionString,
 }

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -15,7 +15,9 @@ function getDefaultVersion(yvmPath = defaultYvmPath) {
         const versionJSON = JSON.parse(versionJSONString)
         const version = versionJSON.defaultVersion
         if (!version) {
-            throw new Error(`Version JSON exists but contains no key 'defaultVersion'`)
+            throw new Error(
+                `Version JSON exists but contains no key 'defaultVersion'`,
+            )
         }
         return version
     } catch (e) {

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -122,7 +122,8 @@ argParser
         }
     });
 
-command('version')
+argParser
+    .command('version')
     .description('Outputs the version of yvm that is installed')
     .action(() => {
         const yvmVersion = require('./commands/yvmVersion');

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -4,35 +4,6 @@ command=$1
 YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}
 export_yvm_dir_string="export YVM_DIR=${YVM_DIR}"
 
-save_last_used_yarn_version() {
-    yarn_version="${1}"
-    if [ -z "$yarn_version" ]; then
-        yarn_version="$(yarn --version)"
-    fi
-
-    if [ -z "$yarn_version" ]; then
-        return
-    fi
-    
-    if [ -e ~/.zshrc ]; then
-        if ! grep -q "LAST_USED_YARN_VERSION" ~/.zshrc; then
-            sed -itmp 's/.*YVM_DIR.*/export LAST_USED_YARN_VERSION='"${yarn_version}"'\'$'\n&/g' ~/.zshrc
-        else
-            sed -itmp "s/LAST_USED_YARN_VERSION.*/LAST_USED_YARN_VERSION=${yarn_version}/" ~/.zshrc
-        fi
-        rm ~/.zshrctmp
-    fi
-
-    if [ -e ~/.bash_profile ]; then
-        if ! grep -q "LAST_USED_YARN_VERSION" ~/.bash_profile; then
-            sed -itmp 's/.*YVM_DIR.*/export LAST_USED_YARN_VERSION='"${yarn_version}"'\'$'\n&/g' ~/.bash_profile
-        else
-            sed -itmp "s/LAST_USED_YARN_VERSION.*/LAST_USED_YARN_VERSION=${yarn_version}/" ~/.bash_profile
-        fi
-        rm ~/.bash_profiletmp
-    fi
-}
-
 yvm_use() {
     local PROVIDED_VERSION=${1}
     NEW_PATH=$(yvm_call_node_script get-new-path ${PROVIDED_VERSION})
@@ -40,12 +11,7 @@ yvm_use() {
         yvm_err "Could not get new path from yvm"
     else
         PATH=${NEW_PATH}
-        YARN_VERSION="$(yarn --version)"
-        CURRENT_GLOBAL_YARN_VERSION="${LAST_USED_YARN_VERSION:-}"
         yvm_echo "Now using yarn version $(yarn --version)"
-        if [ ! -e .yvmrc ] && [ "$YARN_VERSION" != "$CURRENT_GLOBAL_YARN_VERSION" ]; then
-            save_last_used_yarn_version ${1}
-        fi
     fi
 }
 
@@ -82,9 +48,6 @@ yvm_() {
         curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash
     else
         yvm_call_node_script $@
-        if [ "${command}" = "install" ]; then
-            yvm_use $2
-        fi
     fi
 }
 
@@ -92,15 +55,15 @@ if [ ${interactive} = 1 ]; then
     yvm() {
         yvm_ 'function' $@
     }
-    last_used_yarn="${LAST_USED_YARN_VERSION:-}"
-    if [ -z "$last_used_yarn" ]; then
-        yvm_echo "No default yarn version set. Use yvm install <version> or yvm use <version> to fix this"
+    local DEFAULT_YARN_VERSION=$(yvm_call_node_script get-default-version)
+    if [ "x" = "x${DEFAULT_YARN_VERSION}" ]; then
+        yvm_echo "Use yvm set-default <version>"
     else
         if ! type "node" > /dev/null; then
             yvm_echo "YVM Could not automatically set yarn version."
             yvm_echo "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bash_profile"
         else
-            yvm_use ${last_used_yarn}
+            yvm_use
         fi
     fi
 else

--- a/test/util/version.test.js
+++ b/test/util/version.test.js
@@ -1,0 +1,41 @@
+const mockFS = require('mock-fs')
+const { yvmInstalledVersion } = require('../../src/util/yvmInstalledVersion')
+
+describe('yvm installed version', () => {
+    const mockYVMDir = '/mock-yvm-root-dir'
+    afterEach(mockFS.restore)
+
+    it('Finds version if installed', () => {
+        const mockVersion = 'v1.2.3'
+        mockFS({
+            [mockYVMDir]: {
+                '.version': `{ "version": "${mockVersion}" }`,
+            },
+        })
+        expect(yvmInstalledVersion(mockYVMDir)).toEqual(mockVersion)
+    })
+
+    it('fails to find version if no file', () => {
+        expect(yvmInstalledVersion(mockYVMDir)).toBeUndefined()
+    })
+
+    it('fails to find version if file does not contain valid json', () => {
+        const mockVersion = 'v1.2.3'
+        mockFS({
+            [mockYVMDir]: {
+                '.version': `{ "${mockVersion}" }`,
+            },
+        })
+        expect(yvmInstalledVersion(mockYVMDir)).toBeUndefined()
+    })
+
+    it('fails to find version if file does not valid json with "version" key', () => {
+        const mockVersion = 'v1.2.3'
+        mockFS({
+            [mockYVMDir]: {
+                '.version': `{ "version_not_key": "${mockVersion}" }`,
+            },
+        })
+        expect(yvmInstalledVersion(mockYVMDir)).toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Description
Motivation was originally to fix #181 + #180 . Found a better approach which works in a few more cases. 
Removes the need for #134 + #163 
Fixes #181 + #180 

This approach sets a global yvm yarn version. Then any command run will look for the yvm version to use as follows:
- Looks for version in command string
- Looks for rcfile
- Looks for global version


## DevQA

### DevQA Prep
- Install the latest version and .sh commands.

### DevQA Steps
- Open a new shell (Should see the please set default version)
- Follow the instructions and open a new terminal, should load and have a default version of yarn set
- If you have a .yarnrc in the folder your shell opened up in, will set to that yarn version

- All commands such as yvm use, yvm install etc will follow the approach of:
- Looks for version in command string
- Looks for rcfile
- Looks for global version



### Comments:
After this will create a ticket to update `yvm list` to show the default version

Also after this will create an issue for version validation.

