### PR TITLE
bugfix: duplicate help command

### DIFF
--- a/src/yvm.js
+++ b/src/yvm.js
@@ -135,10 +135,5 @@ argParser
     .description('Updates yvm to the latest version')
     .action(invalidCommandLog);
 
-argParser
-    .command('help')
-    .description('Show help text')
-    .action(() => argParser.outputHelp());
-
 /* eslint-enable global-require,prettier/prettier */
 argParser.parse(process.argv)


### PR DESCRIPTION
## Description
Before:
```
    set-default <version>     Sets the default fallback yarn version, if not supplied and no .yvmrc found
    get-default-version       Gets the default set yarn version
    version                   Outputs the version of yvm that is installed
    update-self               Updates yvm to the latest version
    help                      Show help text
    help [cmd]                display help for [cmd]
```
<img width="840" alt="screen shot 2018-12-04 at 6 21 11 pm" src="https://user-images.githubusercontent.com/3534236/49479582-8aa44300-f7f1-11e8-9380-9543d5c15595.png">

After:
```
    set-default <version>     Sets the default fallback yarn version, if not supplied and no .yvmrc found
    get-default-version       Gets the default set yarn version
    version                   Outputs the version of yvm that is installed
    update-self               Updates yvm to the latest version
    help                      Show help text
```
