### PR TITLE
Revert "fix: make sure greenkeeper can generate lockfiles"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,7 @@ jobs:
     working_directory: ~/repo/website
     steps:
       - prep_env
-      - run: |
-          if [[ ${CIRCLE_BRANCH} == greenkeeper* ]]; then
-            yarn install
-          else
-            yarn install --frozen-lockfile
-          fi
+      - run: yarn install --frozen-lockfile
       - save_env_cache
       - run: yarn build
       - persist_to_workspace:

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,7 @@ ifdef CI
     JEST_ENV_VARIABLES=JEST_SUITE_NAME=yvm JEST_JUNIT_OUTPUT=$(TEST_REPORTS_DIR)/tests/jest.junit.xml
     JEST_ARGS=--ci --maxWorkers=2 --reporters jest-junit
     WEBPACK_ARGS=
-ifneq (,$(findstring greenkeeper,$(CIRCLE_BRANCH)))
-    YARN_INSTALL_ARGS=
-else
     YARN_INSTALL_ARGS=--frozen-lockfile --ci
-endif
 else
     ESLINT_EXTRA_ARGS=
     JEST_ENV_VARIABLES=


### PR DESCRIPTION
Reverts tophat/yvm#199

This is an issue on greenkeepers end:
https://github.com/greenkeeperio/greenkeeper/issues/981