### PR TITLE
Clean up creation of prod node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ docker_defaults: &docker_defaults
 
 commands:
   prep_env:
-    description: "Prepapres environment with cache and yvm"
+    description: "Prepares environment with cache and yvm"
     steps:
       - checkout:
           path: ~/repo

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules
+node_modules_production
 artifacts
 .yvm
 website

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ install-watch: node_modules
 
 .PHONY: build-production
 build-production: node_modules node_modules_production
+	ls -la $(NODE_MODULES_BIN)
 	$(WEBPACK) --config webpack/webpack.config.production.js
 
 .PHONY: build-dev

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,7 @@ install-watch: node_modules
 # ---- Webpack ----
 
 .PHONY: build-production
-build-production: node_modules
-	$(YARN) install --modules-folder node_modules_production --production
-	make node_modules
-	du -hs node_modules
-	du -hs node_modules_production
+build-production: node_modules node_modules_production
 	$(WEBPACK) --config webpack/webpack.config.production.js
 
 .PHONY: build-dev
@@ -112,6 +108,11 @@ test-snapshots: node_modules
 node_modules:
 	$(YARN) install ${YARN_INSTALL_ARGS}
 	touch node_modules
+
+.PHONY: node_modules_production
+node_modules_production:
+	$(YARN) install ${YARN_INSTALL_ARGS} --modules-folder node_modules_production --production
+	touch node_modules_production
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install-watch: node_modules
 # ---- Webpack ----
 
 .PHONY: build-production
-build-production: node_modules node_modules_production
+build-production: node_modules_production node_modules
 	ls -la $(NODE_MODULES_BIN)
 	$(WEBPACK) --config webpack/webpack.config.production.js
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ install-watch: node_modules
 
 .PHONY: build-production
 build-production: node_modules_production node_modules
-	ls -la $(NODE_MODULES_BIN)
 	$(WEBPACK) --config webpack/webpack.config.production.js
 
 .PHONY: build-dev


### PR DESCRIPTION
## Description
- Pulls creation of `node_modules_production` to new make task
- Removes duplication install of `node_modules`
- Removes test information

## DevQA
### DevQA Steps
- Run `make build-production`, it should produce the same artifacts before and after this PR


