### PR TITLE
Prevent yvm.zip from including itself; force overwrite in dev install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,6 @@ trap 'err_report $LINENO' ERR
 USE_LOCAL=${USE_LOCAL-false}
 
 release_api_url="https://api.github.com/repos/tophat/yvm/releases/latest"
-artifacts_dir="artifacts/webpack_build"
 
 YVM_DIR=${YVM_INSTALL_DIR-"${HOME}/.yvm"}
 zip_download_path="${YVM_DIR}/yvm.zip"
@@ -29,7 +28,7 @@ mkdir -p ${YVM_ALIAS_DIR}
 if [ "$USE_LOCAL" = true ]; then
     rm -f "${YVM_DIR}/yvm.sh" "${YVM_DIR}/yvm.js" "${YVM_DIR}/yvm-exec.js"
     rm -rf "${YVM_DIR}/node_modules"
-    unzip -o -q artifacts/webpack_build/yvm.zip -d ${YVM_DIR}
+    unzip -o -q artifacts/yvm.zip -d ${YVM_DIR}
     chmod +x ${YVM_DIR}/yvm.sh
 else
     release_api_contents=$(curl -s ${release_api_url} )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,7 @@ mkdir -p ${YVM_ALIAS_DIR}
 if [ "$USE_LOCAL" = true ]; then
     rm -f "${YVM_DIR}/yvm.sh" "${YVM_DIR}/yvm.js" "${YVM_DIR}/yvm-exec.js"
     rm -rf "${YVM_DIR}/node_modules"
-    unzip -q artifacts/webpack_build/yvm.zip -d ${YVM_DIR}
+    unzip -o -q artifacts/webpack_build/yvm.zip -d ${YVM_DIR}
     chmod +x ${YVM_DIR}/yvm.sh
 else
     release_api_contents=$(curl -s ${release_api_url} )

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -3,10 +3,7 @@ const path = require('path')
 
 const ghRelease = require('gh-release')
 
-const YVM_ZIP_FILE = path.join(
-    process.cwd(),
-    '/artifacts/webpack_build/yvm.zip',
-)
+const YVM_ZIP_FILE = path.join(process.cwd(), '/artifacts/yvm.zip')
 
 const releaseVersion = process.env.VERSION
 

--- a/webpack/webpack.config.production.js
+++ b/webpack/webpack.config.production.js
@@ -4,6 +4,7 @@ const ZipFilesPlugin = require('webpack-zip-files-plugin')
 const baseConfig = require('./webpack.config.base')
 
 const outputPath = baseConfig.output.path
+const artifactsPath = path.resolve(outputPath, '..')
 const nodeModulesProductionPath = path.resolve(
     __dirname,
     '..',
@@ -16,7 +17,7 @@ baseConfig.plugins.push(
             { src: outputPath, dist: '.' },
             { src: nodeModulesProductionPath, dist: 'node_modules' },
         ],
-        output: path.join(outputPath, 'yvm'),
+        output: path.join(artifactsPath, 'yvm'),
         format: 'zip',
     }),
 )


### PR DESCRIPTION
## Description
- A bug in https://www.npmjs.com/package/webpack-zip-files-plugin makes it include the output file in itself if the file is created in the directory being zipped up
- This PR changes the output path of `yvm.zip` to be `./artifacts/yvm.zip` instead of `./artifacts/webpack_build/yvm.zip`
- This PR also forces `unzip` to overwrite any files when installing using `make install`. It was already doing that when using the `curl | bash` method


## DevQA

### DevQA Steps
- Running `make install` more than once should not prompt for overwrite, it should just do it.
- The output `yvm.zip` should be located in the `artiacts` directory
- Extracting or listing the contents of `yvm.zip` should not show another `yvm.zip` within