### PR TITLE
Fix bash error: "local can only be used in a function"

### DIFF
--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -55,7 +55,7 @@ if [ ${interactive} = 1 ]; then
     yvm() {
         yvm_ 'function' $@
     }
-    local DEFAULT_YARN_VERSION=$(yvm_call_node_script get-default-version)
+    DEFAULT_YARN_VERSION=$(yvm_call_node_script get-default-version)
     if [ "x" = "x${DEFAULT_YARN_VERSION}" ]; then
         yvm_echo "Use yvm set-default <version>"
     else


### PR DESCRIPTION
When opening a new shell in bash, yvm gives the following error:

```
-bash: local: can only be used in a function
```

I believe this fixes it. Still untested.

UPDATE: modified files locally and this does indeed fix the error.