### PR TITLE
Change installation script (#225, #227)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@ zip_download_path="${YVM_DIR}/yvm.zip"
 sh_install_path="${YVM_DIR}/yvm.sh"
 
 export_yvm_dir_string="export YVM_DIR=${YVM_DIR}"
-executable_source_string="source ${sh_install_path}"
+executable_source_string='[ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh'
 
 mkdir -p ${YVM_DIR}
 
@@ -53,21 +53,21 @@ if ! grep -q "${export_yvm_dir_string}" ~/.zshrc; then
     added_newline=1
 fi
 
-if ! grep -q "${executable_source_string}" ~/.zshrc; then
+if ! grep -qF "${executable_source_string}" ~/.zshrc; then
     [ -z "${added_newline}" ] && echo '' >> ~/.zshrc
     echo ${executable_source_string} >> ~/.zshrc
 fi
 
 added_newline=0
-if ! grep -q "${export_yvm_dir_string}" ~/.bash_profile; then
-    echo '' >> ~/.bash_profile
-    echo ${export_yvm_dir_string} >> ~/.bash_profile
+if ! grep -q "${export_yvm_dir_string}" ~/.bashrc; then
+    echo '' >> ~/.bashrc
+    echo ${export_yvm_dir_string} >> ~/.bashrc
     added_newline=1
 fi
 
-if ! grep -q "${executable_source_string}" ~/.bash_profile; then
-    [ -z "${added_newline}" ] && echo '' >> ~/.bash_profile
-    echo ${executable_source_string} >> ~/.bash_profile
+if ! grep -qF "${executable_source_string}" ~/.bashrc; then
+    [ -z "${added_newline}" ] && echo '' >> ~/.bashrc
+    echo ${executable_source_string} >> ~/.bashrc
 fi
 
 echo "yvm successfully installed in ${YVM_DIR} as ${sh_install_path}"

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -61,7 +61,7 @@ if [ ${interactive} = 1 ]; then
     else
         if ! type "node" > /dev/null; then
             yvm_echo "YVM Could not automatically set yarn version."
-            yvm_echo "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bash_profile"
+            yvm_echo "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bashrc"
         else
             yvm_use
         fi


### PR DESCRIPTION
Change the installation script so that it setups bash in .bashrc and not
in .bash_profile. Note that this leaves users that have previously
installed with sourcing in two places - this is acceptable as it does
not bring harm, except wasting CPU on parsing the script twice.

Also change the way files are include (both in bash and in zsh), adding
guards if the file exists. This avoids error messages if user at some
point deletes $YVM_DIR.

## Description
Installation script:
- install (for bash) in `~/.bashrc`
- add guards (for bash/zsh) against missing file

## DevQA

### DevQA Prep

### DevQA Steps
- check that `~/.bash_profile` is not modified
- check that `~/.bashrc` is modified
- check that `yvm` works by default when launching new shell
- check that `~/.bashrc` and `~/.zshrc` are untouched by second installation
- check that neither bash nor zsh display any error message when ~/.yvm is removed

### Comments:
Fixes #225 
Fixes #227