### PR TITLE
Add Global default while printing versions

### DIFF
--- a/src/commands/getNewPath.js
+++ b/src/commands/getNewPath.js
@@ -1,6 +1,7 @@
 const path = require('path')
 
-const { versionRootPath, yvmPath } = require('../util/utils')
+const { versionRootPath } = require('../util/utils')
+const { yvmPath } = require('../util/path')
 
 const getNewPath = (
     version,

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -8,8 +8,8 @@ const {
     versionRootPath,
     getExtractionPath,
     getVersionsFromTags,
-    yvmPath,
 } = require('../util/utils')
+const { yvmPath } = require('../util/path')
 
 const directoryStack = []
 

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -2,11 +2,8 @@ const fs = require('fs')
 const { exec } = require('shelljs')
 
 const log = require('../util/log')
-const {
-    printVersions,
-    stripVersionPrefix,
-    versionRootPath,
-} = require('../util/utils')
+const { stripVersionPrefix, versionRootPath } = require('../util/utils')
+const { printVersions } = require('../util/version')
 const { yvmPath } = require('../util/path')
 
 const getYarnVersions = rootPath => {

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -6,8 +6,8 @@ const {
     printVersions,
     stripVersionPrefix,
     versionRootPath,
-    yvmPath,
 } = require('../util/utils')
+const { yvmPath } = require('../util/path')
 
 const getYarnVersions = rootPath => {
     const re = /^v(\d+\.)(\d+\.)(\d+)$/

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -29,7 +29,11 @@ const listVersions = (rootPath = yvmPath) => {
             { async: true, silent: true },
             (code, stdout) => {
                 const versionInUse = stdout
-                printVersions(installedVersions, message, versionInUse)
+                printVersions({
+                    list: installedVersions,
+                    message,
+                    versionInUse,
+                })
             },
         )
     } else {

--- a/src/commands/listRemote.js
+++ b/src/commands/listRemote.js
@@ -6,7 +6,10 @@ const listRemoteCommand = () => {
 
     return getVersionsFromTags()
         .then(versions => {
-            printVersions(versions, 'Versions available for install:')
+            printVersions({
+                list: versions,
+                message: 'Versions available for install:',
+            })
         })
         .catch(error => {
             log(error)

--- a/src/commands/listRemote.js
+++ b/src/commands/listRemote.js
@@ -1,5 +1,6 @@
 const log = require('../util/log')
-const { getVersionsFromTags, printVersions } = require('../util/utils')
+const { getVersionsFromTags } = require('../util/utils')
+const { printVersions } = require('../util/version')
 
 const listRemoteCommand = () => {
     log.info('list-remote')

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -1,7 +1,9 @@
 const fs = require('fs-extra')
 const shell = require('shelljs')
 
-const { getExtractionPath, yvmPath } = require('../util/utils')
+const { getExtractionPath } = require('../util/utils')
+const { yvmPath } = require('../util/path')
+
 const log = require('../util/log')
 
 const removeVersion = (version, rootPath = yvmPath) => {

--- a/src/commands/which.js
+++ b/src/commands/which.js
@@ -1,7 +1,8 @@
 const shell = require('shelljs')
 const { getRcFileVersion } = require('../util/version')
 const log = require('../util/log')
-const { yvmPath, versionRootPath } = require('../util/utils')
+const { versionRootPath } = require('../util/utils')
+const { yvmPath } = require('../util/path')
 
 const whichCommand = (inputPath, testPath = '') => {
     if (!shell.which('yarn')) {

--- a/src/util/install.js
+++ b/src/util/install.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 
-const { getExtractionPath, yvmPath } = require('../util/utils')
+const { getExtractionPath } = require('../util/utils')
+const { yvmPath } = require('../util/path')
+
 const installVersion = require('../commands/install')
 
 const ensureVersionInstalled = (version, rootPath = yvmPath) => {

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -1,0 +1,5 @@
+const os = require('os')
+const path = require('path')
+
+const yvmPath = process.env.YVM_DIR || path.resolve(os.homedir(), '.yvm')
+module.exports = { yvmPath }

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -3,8 +3,9 @@ const path = require('path')
 const request = require('request')
 
 const log = require('./log')
-
+const { getDefaultVersion } = require('./version')
 const yvmPath = process.env.YVM_DIR || path.resolve(os.homedir(), '.yvm')
+const DEFAULT_VERSION_TEXT = 'Global Default'
 const versionRootPath = rootPath => path.resolve(rootPath, 'versions')
 
 const getExtractionPath = (version, rootPath) =>
@@ -13,26 +14,34 @@ const getExtractionPath = (version, rootPath) =>
 const stripVersionPrefix = tagName =>
     tagName[0] === 'v' ? tagName.substring(1) : tagName
 
-const printVersions = (list, message, versionInUse = '') => {
+const printVersions = ({
+    list,
+    message,
+    versionInUse = '',
+    defaultVersion = getDefaultVersion(yvmPath),
+}) => {
     log(message)
 
     versionInUse = versionInUse.trim()
 
     const versionsMap = {}
 
-    list.forEach(item => {
-        const itemTrimmed = item.trim()
+    list.forEach(versionPadded => {
+        const version = versionPadded.trim()
 
-        const toLog =
-            itemTrimmed === versionInUse ? ` \u2713 ${item}` : ` - ${item}`
+        let toLog =
+            version === versionInUse
+                ? ` \u2713 ${versionPadded}`
+                : ` - ${versionPadded}`
 
-        if (itemTrimmed === versionInUse) {
+        if (version === defaultVersion) toLog += ` (${DEFAULT_VERSION_TEXT})`
+        if (version === versionInUse) {
             log('\x1b[32m%s\x1b[0m', toLog)
         } else {
             log(toLog)
         }
 
-        versionsMap[itemTrimmed] = toLog
+        versionsMap[version] = toLog
     })
     return versionsMap
 }

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -1,9 +1,6 @@
 const path = require('path')
 const request = require('request')
-const { yvmPath } = require('./path')
-const log = require('./log')
-const { getDefaultVersion } = require('./version')
-const DEFAULT_VERSION_TEXT = 'Global Default'
+
 const versionRootPath = rootPath => path.resolve(rootPath, 'versions')
 
 const getExtractionPath = (version, rootPath) =>
@@ -11,38 +8,6 @@ const getExtractionPath = (version, rootPath) =>
 
 const stripVersionPrefix = tagName =>
     tagName[0] === 'v' ? tagName.substring(1) : tagName
-
-const printVersions = ({
-    list,
-    message,
-    versionInUse = '',
-    defaultVersion = getDefaultVersion(yvmPath),
-}) => {
-    log(message)
-
-    versionInUse = versionInUse.trim()
-
-    const versionsMap = {}
-
-    list.forEach(versionPadded => {
-        const version = versionPadded.trim()
-
-        let toLog =
-            version === versionInUse
-                ? ` \u2713 ${versionPadded}`
-                : ` - ${versionPadded}`
-
-        if (version === defaultVersion) toLog += ` (${DEFAULT_VERSION_TEXT})`
-        if (version === versionInUse) {
-            log('\x1b[32m%s\x1b[0m', toLog)
-        } else {
-            log(toLog)
-        }
-
-        versionsMap[version] = toLog
-    })
-    return versionsMap
-}
 
 const getVersionsFromTags = () => {
     const options = {
@@ -71,7 +36,6 @@ const getVersionsFromTags = () => {
 module.exports = {
     getExtractionPath,
     getVersionsFromTags,
-    printVersions,
     stripVersionPrefix,
     versionRootPath,
 }

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -1,10 +1,8 @@
-const os = require('os')
 const path = require('path')
 const request = require('request')
-
+const { yvmPath } = require('./path')
 const log = require('./log')
 const { getDefaultVersion } = require('./version')
-const yvmPath = process.env.YVM_DIR || path.resolve(os.homedir(), '.yvm')
 const DEFAULT_VERSION_TEXT = 'Global Default'
 const versionRootPath = rootPath => path.resolve(rootPath, 'versions')
 
@@ -76,5 +74,4 @@ module.exports = {
     printVersions,
     stripVersionPrefix,
     versionRootPath,
-    yvmPath,
 }

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const cosmiconfig = require('cosmiconfig')
 const log = require('./log')
-const { yvmPath: defaultYvmPath } = require('./utils')
+const { yvmPath: defaultYvmPath } = require('./path')
 
 function isValidVersionString(version) {
     return /^\d+\.\d+\.\d+$/.test(version)

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -3,6 +3,7 @@ const path = require('path')
 const cosmiconfig = require('cosmiconfig')
 const log = require('./log')
 const { yvmPath: defaultYvmPath } = require('./path')
+const DEFAULT_VERSION_TEXT = 'Global Default'
 
 function isValidVersionString(version) {
     return /^\d+\.\d+\.\d+$/.test(version)
@@ -94,10 +95,43 @@ Try:
     }
 }
 
+const printVersions = ({
+    list,
+    message,
+    versionInUse = '',
+    defaultVersion = getDefaultVersion(defaultYvmPath),
+}) => {
+    log(message)
+
+    versionInUse = versionInUse.trim()
+
+    const versionsMap = {}
+
+    list.forEach(versionPadded => {
+        const version = versionPadded.trim()
+
+        let toLog =
+            version === versionInUse
+                ? ` \u2713 ${versionPadded}`
+                : ` - ${versionPadded}`
+
+        if (version === defaultVersion) toLog += ` (${DEFAULT_VERSION_TEXT})`
+        if (version === versionInUse) {
+            log('\x1b[32m%s\x1b[0m', toLog)
+        } else {
+            log(toLog)
+        }
+
+        versionsMap[version] = toLog
+    })
+    return versionsMap
+}
+
 module.exports = {
     getRcFileVersion,
     getSplitVersionAndArgs,
     getDefaultVersion,
     setDefaultVersion,
     isValidVersionString,
+    printVersions,
 }

--- a/src/util/yvmInstalledVersion.js
+++ b/src/util/yvmInstalledVersion.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
-const { yvmPath } = require('./utils')
+const { yvmPath } = require('./path')
 const log = require('./log')
 
 const yvmInstalledVersion = (inYvmPath = yvmPath) => {

--- a/src/yvm-exec.js
+++ b/src/yvm-exec.js
@@ -4,7 +4,7 @@ const { exec } = require('shelljs')
 const { ensureVersionInstalled } = require('./util/install')
 const { getSplitVersionAndArgs } = require('./util/version')
 const log = require('./util/log')
-const { yvmPath } = require('./util/utils')
+const { yvmPath } = require('./util/path')
 
 const getYarnPath = (version, rootPath) =>
     path.resolve(rootPath, `versions/v${version}`)

--- a/test/commands/list.test.js
+++ b/test/commands/list.test.js
@@ -45,9 +45,13 @@ describe('yvm list', () => {
 
     it('Correctly highlights active yarn version', () => {
         const listOutput = getList()
-        const versionsMap = printVersions(listOutput, 'test', '1.7.0')
-        expect(versionsMap['1.7.0']).toBe(` \u2713 1.7.0`)
-        expect(versionsMap['1.6.0']).toBe(` - 1.6.0`)
+        const versionsMap = printVersions({
+            list: listOutput,
+            message: 'test',
+            versionInUse: '1.7.0',
+        })
+        expect(versionsMap['1.7.0']).toContain(` \u2713 1.7.0`)
+        expect(versionsMap['1.6.0']).toContain(` - 1.6.0`)
     })
 
     it('Returns nothing if nothing installed', () => {

--- a/test/commands/list.test.js
+++ b/test/commands/list.test.js
@@ -3,10 +3,10 @@ const fs = require('fs-extra')
 const list = require('../../src/commands/list')
 const {
     getExtractionPath,
-    printVersions,
     stripVersionPrefix,
     versionRootPath,
 } = require('../../src/util/utils')
+const { printVersions } = require('../../src/util/version')
 
 describe('yvm list', () => {
     const garbageInDirectory = ['haxor']

--- a/test/util/utils.test.js
+++ b/test/util/utils.test.js
@@ -1,4 +1,4 @@
-const { printVersions } = require('../../src/util/utils')
+const { printVersions } = require('../../src/util/version')
 
 const DEFAULT_VERSION_TEXT = 'Global Default'
 const VERSION_IN_USE_SYMBOL = `\u2713`

--- a/test/util/utils.test.js
+++ b/test/util/utils.test.js
@@ -1,0 +1,31 @@
+const { printVersions } = require('../../src/util/utils')
+
+const DEFAULT_VERSION_TEXT = 'Global Default'
+const VERSION_IN_USE_SYMBOL = `\u2713`
+
+const versions = ['1.1.0', '1.2.0', '1.3.0']
+const versionInUse = '1.2.0'
+const defaultVersion = '1.3.0'
+
+describe('Util functions', () => {
+    it('Returns same number of versions passed to printVersion function', () => {
+        const versionsObject = printVersions({ list: versions, versionInUse })
+        expect(Object.keys(versionsObject)).toHaveLength(versions.length)
+    })
+
+    it('Highlights the version currently in use', () => {
+        const versionsObject = printVersions({ list: versions, versionInUse })
+        expect(versionsObject[versionInUse]).toBeDefined()
+        expect(versionsObject[versionInUse]).toContain(VERSION_IN_USE_SYMBOL)
+    })
+
+    it('Highlights the  default version', () => {
+        const versionsObject = printVersions({
+            list: versions,
+            versionInUse,
+            defaultVersion,
+        })
+        expect(versionsObject[defaultVersion]).toBeDefined()
+        expect(versionsObject[defaultVersion]).toContain(DEFAULT_VERSION_TEXT)
+    })
+})


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
Fix #193 
When printing the version of the yvm installed/available, it should show the default global version
It also moves the path logic out of utils.js to another helper file path.js so that no cyclic dependency is introduced.

## DevQA

### DevQA Prep

### DevQA Steps
- `make Install`
- `yvm list`


### Comments:
![image](https://user-images.githubusercontent.com/1558352/49507136-d6b0bf80-f8a5-11e8-9712-583ab58dcb4c.png)

![image](https://user-images.githubusercontent.com/1558352/49508946-0bbf1100-f8aa-11e8-8168-36aaa111543d.png)


