### PR TITLE
Have 'make clean' remover production-mode node_modules as well (#237)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,6 @@ node_modules_production:
 
 .PHONY: clean
 clean:
-	rm -rf ${ARTIFACT_DIR}
+	rm -rf ${ARTIFACT_DIR} node_modules_production
 	rm -f ~/.babel.json
 	rm -rf node_modules


### PR DESCRIPTION
## Description
Makefile changed to remove node_modules added by production  build

## DevQA

### DevQA Prep

### DevQA Steps
1. Run `make build-production`
2. Check that directory 'node_modules_production` has been created
3. Run `make clean`
2. Check that the directory was removed

### Comments:
Fixes #237 


