### PR TITLE
Automatically source yvm.sh in dev mode 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
           at: ./
       - add_ssh_keys:
           fingerprints:
-            - "e4:57:c7:5a:d1:6f:a9:23:20:fe:5f:bb:77:39:33:bb"
+            - "31:a5:c5:3d:78:b9:79:1d:2f:4b:59:fd:e1:89:21:dc"
       - run:
           name: Setup git user and deploy website
           command: |

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",
     "webpack-node-externals": "^1.7.2",
+    "webpack-shell-plugin-next": "^0.6.4",
     "webpack-zip-files-plugin": "^1.0.0"
   },
   "lint-staged": {

--- a/webpack/webpack.config.development.js
+++ b/webpack/webpack.config.development.js
@@ -1,5 +1,17 @@
 const baseConfig = require('./webpack.config.base')
+const WebpackShellPlugin = require('webpack-shell-plugin-next')
 
 baseConfig.mode = 'development'
+
+const basePlugins = baseConfig.plugins
+baseConfig.plugins = [
+    ...basePlugins,
+    new WebpackShellPlugin({
+        onBuildExit: {
+            scripts: ['source src/yvm.sh'],
+            blocking: true,
+        },
+    }),
+]
 
 module.exports = baseConfig

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,14 @@ babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-jest@^23.0.1:
   version "23.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz#631cc545c6cf021943013bcaf22f45d87fe62198"
@@ -5615,6 +5623,10 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
 regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
@@ -6868,6 +6880,12 @@ webpack-cli@^3.0.8:
 webpack-node-externals@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+
+webpack-shell-plugin-next@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/webpack-shell-plugin-next/-/webpack-shell-plugin-next-0.6.4.tgz#3294b12931a49aa8b7162eaf5adac2416801d7e7"
+  dependencies:
+    babel-polyfill "^6.26.0"
 
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Description
We should automatically source yvm.sh in dev mode whenever any local changes are made. Addresses #140 

## DevQA


### DevQA Steps
- Run `make install-watch`
- Make a change to one of the commands (like adding a console.log somewhere)
- Wait for webpack to build 
- Run the command
- See that your log shows up without explicitly running `source yvm.sh` 🎉 