### PR TITLE
Create new command to install latest version

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -89,8 +89,7 @@
       "avatar_url": "https://avatars0.githubusercontent.com/u/8632167?v=4",
       "profile": "http://www.sanchitgera.ca",
       "contributions": [
-        "doc",
-        "code"
+        "doc"
       ]
     },
     {

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -89,7 +89,8 @@
       "avatar_url": "https://avatars0.githubusercontent.com/u/8632167?v=4",
       "profile": "http://www.sanchitgera.ca",
       "contributions": [
-        "doc"
+        "doc",
+        "code"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ To download and install a version of yarn, run:
 yvm install <version>
 ```
 
+To get the latest version of Yarn, run:
+
+```bash
+yvm install --latest
+```
 Execute an arbitrary command using a specific version of yarn:
 
 ```bash

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -38,6 +38,12 @@ To download and install a version of yarn, run:
 yvm install <version>
 ```
 
+To install the latest version of yarn, run:
+
+```bash
+yvm install --latest
+```
+
 Execute an arbitrary command using a specific version of yarn:
 
 ```bash

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -91,7 +91,7 @@ const downloadAndExtractYarn = (version, rootPath) => {
         })
 }
 
-const installVersion = (version, rootPath = yvmPath) => {
+const install = (version, rootPath = yvmPath) => {
     if (versionInstalled(version, rootPath)) {
         log(`It looks like you already have yarn ${version} installed...`)
         return Promise.resolve()
@@ -112,7 +112,7 @@ const installVersion = (version, rootPath = yvmPath) => {
         })
 }
 
-const installLatestVersion = (rootPath = yvmPath) => {
+const installLatest = (rootPath = yvmPath) => {
     return getVersionsFromTags()
         .then(versions => {
             const latestVersion = versions[0]
@@ -130,4 +130,4 @@ const installLatestVersion = (rootPath = yvmPath) => {
         })
 }
 
-module.exports = { installVersion, installLatestVersion }
+module.exports = { install, installLatest }

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -32,7 +32,7 @@ const cleanDirectories = () => {
     }
 }
 
-const checkForVersion = (version, rootPath) => {
+const versionInstalled = (version, rootPath) => {
     const versionPath = getExtractionPath(version, rootPath)
     checkDirectories(rootPath)
     return fs.existsSync(versionPath)
@@ -80,8 +80,19 @@ const extractYarn = (version, rootPath) => {
     })
 }
 
+const downloadAndExtractYarn = (version, rootPath) => {
+    return downloadVersion(version, rootPath)
+        .then(() => {
+            return extractYarn(version, rootPath)
+        })
+        .catch(error => {
+            log(error)
+            cleanDirectories()
+        })
+}
+
 const installVersion = (version, rootPath = yvmPath) => {
-    if (checkForVersion(version, rootPath)) {
+    if (versionInstalled(version, rootPath)) {
         log(`It looks like you already have yarn ${version} installed...`)
         return Promise.resolve()
     }
@@ -94,14 +105,9 @@ const installVersion = (version, rootPath = yvmPath) => {
                 return Promise.reject()
             }
             log(`Installing yarn v${version} in ${rootPath}`)
-            return downloadVersion(version, rootPath)
-        })
-        .then(() => {
-            log(`Finished downloading yarn version ${version}`)
-            return extractYarn(version, rootPath)
+            return downloadAndExtractYarn(version, rootPath)
         })
         .catch(err => {
-            cleanDirectories()
             log(err)
         })
 }
@@ -110,21 +116,16 @@ const installLatestVersion = (rootPath = yvmPath) => {
     return getVersionsFromTags()
         .then(versions => {
             const latestVersion = versions[0]
-            if (checkForVersion(latestVersion, rootPath)) {
+            if (versionInstalled(latestVersion, rootPath)) {
                 log(
                     `It looks like you already have yarn ${latestVersion} installed...`,
                 )
                 return Promise.resolve()
             }
             log(`Installing yarn v${latestVersion}`)
-            return downloadVersion(latestVersion, rootPath)
-        })
-        .then(installedVersion => {
-            log(`Finished downloading yarn version ${installedVersion}`)
-            return extractYarn(installedVersion, rootPath)
+            return downloadAndExtractYarn(latestVersion, rootPath)
         })
         .catch(err => {
-            cleanDirectories()
             log(err)
         })
 }

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -36,12 +36,12 @@ argParser
     .option('-l, --latest', 'Install the latest version of Yarn available')
     .description('Install the specified version of Yarn.')
     .action((maybeVersion, command) => {
-        const {installVersion, installLatestVersion} = require('./commands/install');
+        const {install, installLatest} = require('./commands/install');
 
-        if(command.latest) return installLatestVersion()
+        if(command.latest) return installLatest()
 
         const [version] = getSplitVersionAndArgs(maybeVersion);
-        installVersion(version);
+        install(version);
     });
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -33,11 +33,16 @@ if (!process.argv.includes('exec')) {
 argParser
     .command('install [version]')
     .alias('i')
+    .option('-l, --latest', 'Install the latest version of Yarn available')
     .description('Install the specified version of Yarn.')
-    .action((maybeVersion) => {
+    .action((maybeVersion, command) => {
         const [version] = getSplitVersionAndArgs(maybeVersion);
-        const install = require('./commands/install');
-        install(version);
+        const {installVersion, installLatestVersion} = require('./commands/install');
+
+        if(command.latest) {
+            return installLatestVersion()
+        }
+        installVersion(version);
     });
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -36,12 +36,11 @@ argParser
     .option('-l, --latest', 'Install the latest version of Yarn available')
     .description('Install the specified version of Yarn.')
     .action((maybeVersion, command) => {
-        const [version] = getSplitVersionAndArgs(maybeVersion);
         const {installVersion, installLatestVersion} = require('./commands/install');
 
-        if(command.latest) {
-            return installLatestVersion()
-        }
+        if(command.latest) return installLatestVersion()
+
+        const [version] = getSplitVersionAndArgs(maybeVersion);
         installVersion(version);
     });
 

--- a/test/commands/install.test.js
+++ b/test/commands/install.test.js
@@ -9,6 +9,8 @@ jest.mock('../../src/util/utils', () => {
         getVersionsFromTags: jest.fn().mockImplementation(() => {
             return Promise.resolve(MOCK_REMOTE_VERSIONS)
         }),
+        getExtractionPath,
+        versionRootPath,
     }
 })
 

--- a/test/commands/install.test.js
+++ b/test/commands/install.test.js
@@ -1,7 +1,16 @@
 const fs = require('fs-extra')
 
-const install = require('../../src/commands/install')
+const { install, installLatest } = require('../../src/commands/install')
 const { getExtractionPath, versionRootPath } = require('../../src/util/utils')
+
+jest.mock('../../src/util/utils', () => {
+    const MOCK_REMOTE_VERSIONS = ['1.6.0', '1.0.0']
+    return {
+        getVersionsFromTags: jest.fn().mockImplementation(() => {
+            return Promise.resolve(MOCK_REMOTE_VERSIONS)
+        }),
+    }
+})
 
 describe('yvm install', () => {
     const rootPath = '/tmp/yvmInstall'
@@ -44,6 +53,15 @@ describe('yvm install', () => {
             expect(() =>
                 fs.statSync(getExtractionPath(version, rootPath)),
             ).toThrow()
+        })
+    })
+
+    it('installs the lastest version of yarn', () => {
+        const latestVersion = '1.6.0'
+        return installLatest(rootPath).then(() => {
+            expect(
+                fs.statSync(getExtractionPath(latestVersion, rootPath)),
+            ).toBeTruthy()
         })
     })
 })

--- a/test/commands/install.test.js
+++ b/test/commands/install.test.js
@@ -1,18 +1,11 @@
 const fs = require('fs-extra')
 
 const { install, installLatest } = require('../../src/commands/install')
-const { getExtractionPath, versionRootPath } = require('../../src/util/utils')
-
-jest.mock('../../src/util/utils', () => {
-    const MOCK_REMOTE_VERSIONS = ['1.6.0', '1.0.0']
-    return {
-        getVersionsFromTags: jest.fn().mockImplementation(() => {
-            return Promise.resolve(MOCK_REMOTE_VERSIONS)
-        }),
-        getExtractionPath,
-        versionRootPath,
-    }
-})
+const {
+    getVersionsFromTags,
+    getExtractionPath,
+    versionRootPath,
+} = require('../../src/util/utils')
 
 describe('yvm install', () => {
     const rootPath = '/tmp/yvmInstall'
@@ -59,8 +52,12 @@ describe('yvm install', () => {
     })
 
     it('installs the lastest version of yarn', () => {
-        const latestVersion = '1.6.0'
-        return installLatest(rootPath).then(() => {
+        return Promise.all([
+            getVersionsFromTags(),
+            installLatest(rootPath),
+        ]).then(results => {
+            const remoteVersions = results[0]
+            const latestVersion = remoteVersions[0]
             expect(
                 fs.statSync(getExtractionPath(latestVersion, rootPath)),
             ).toBeTruthy()


### PR DESCRIPTION
## Description
Give users the option to install the latest version of Yarn. Using `yvm install --latest` or `yvm install -l`. 
See #175 

## DevQA

### DevQA Steps
- Run `yvm ls-remote`. Note the latest version of Yarn available 
- Run `yvm install --latest`
- See that the version is installed 
- Run `yvm install --latest` again 
- See that yvm prints a message about version already installed 