### PR TITLE
Less verbose initialization

### DIFF
--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -55,16 +55,13 @@ if [ ${interactive} = 1 ]; then
     yvm() {
         yvm_ 'function' $@
     }
-    DEFAULT_YARN_VERSION=$(yvm_call_node_script get-default-version)
-    if [ "x" = "x${DEFAULT_YARN_VERSION}" ]; then
-        yvm_echo "Use yvm set-default <version>"
-    else
-        if ! type "node" > /dev/null; then
-            yvm_echo "YVM Could not automatically set yarn version."
-            yvm_echo "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bashrc"
-        else
-            yvm_use
-        fi
+    if ! type "node" > /dev/null; then
+        yvm_err "YVM Could not find node executable."
+        yvm_err "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bashrc"
+    fi
+    DEFAULT_YARN_VERSION=$(yvm_call_node_script get-default-version 2>/dev/null)
+    if [ "x" != "x${DEFAULT_YARN_VERSION}" ]; then
+        yvm_use > /dev/null
     fi
 else
     yvm_ 'script' $@


### PR DESCRIPTION
Make initialization (sourcing from bashrc/zshrc) output only error
messages, silence default messages from yvm use.

## Description
Changed `yvm.sh` so that the initialization is quiet, displaying only error messages.


## DevQA

### DevQA Prep

### DevQA Steps
Make sure that initialization is quiet (no message about currently used version), however error messages (e.g. about missing node version) are still present. The message should still be displayed if `yvm use` is used directly.
Please test both `bash` and `zsh`, especially as I don't use `zsh` myself.

### Comments:
Fixes #226 


