### PR TITLE
bugfix: fix crash no method s exists

### DIFF
--- a/src/util/install.js
+++ b/src/util/install.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const { getExtractionPath } = require('../util/utils')
 const { yvmPath } = require('../util/path')
 
-const installVersion = require('../commands/install')
+const { installVersion } = require('../commands/install')
 
 const ensureVersionInstalled = (version, rootPath = yvmPath) => {
     const yarnBinDir = getExtractionPath(version, rootPath)

--- a/src/util/install.js
+++ b/src/util/install.js
@@ -3,14 +3,14 @@ const fs = require('fs')
 const { getExtractionPath } = require('../util/utils')
 const { yvmPath } = require('../util/path')
 
-const { installVersion } = require('../commands/install')
+const { install } = require('../commands/install')
 
 const ensureVersionInstalled = (version, rootPath = yvmPath) => {
     const yarnBinDir = getExtractionPath(version, rootPath)
     if (fs.existsSync(yarnBinDir)) {
         return Promise.resolve()
     }
-    return installVersion(version, rootPath)
+    return install(version, rootPath)
 }
 
 module.exports = {


### PR DESCRIPTION
## Description
Occasionally seeing the issue in CI:
```
#!/bin/bash -eo pipefail
make node_modules
/home/circleci/.yvm/yvm.sh exec install --frozen-lockfile --ci
/home/circleci/.yvm/yvm-exec.js:1
(function (exports, require, module, __filename, __dirname) { !function(n){var r={};function e(t){if(r[t])return r[t].exports;var o=r[t]={i:t,l:!1,exports:{}};return n[t].call(o.exports,o,o.exports,e),o.l=!0,o.exports}e.m=n,e.c=r,e.d=function(n,r,t){e.o(n,r)||Object.defineProperty(n,r,{enumerable:!0,get:t})},e.r=function(n){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(n,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(n,"__esModule",{value:!0})},e.t=function(n,r){if(1&r&&(n=e(n)),8&r)return n;if(4&r&&"object"==typeof n&&n&&n.__esModule)return n;var t=Object.create(null);if(e.r(t),Object.defineProperty(t,"default",{enumerable:!0,value:n}),2&r&&"string"!=typeof n)for(var o in n)e.d(t,o,function(r){return n[r]}.bind(null,o));return t},e.n=function(n){var r=n&&n.__esModule?function(){return n.default}:function(){return n};return e.d(r,"a",r),r},e.o=function(n,r){return Object.prototype.hasOwnProperty.call(n,r)},e.p="",e(e.s=15)}([function(n,r,

TypeError: s is not a function
    at ensureVersionInstalled (/home/circleci/.yvm/yvm-exec.js:1:6130)
    at /home/circleci/.yvm/yvm-exec.js:1:7563
    at Object.<anonymous> (/home/circleci/.yvm/yvm-exec.js:1:7605)
    at e (/home/circleci/.yvm/yvm-exec.js:1:172)
    at Object.<anonymous> (/home/circleci/.yvm/yvm-exec.js:1:7699)
    at e (/home/circleci/.yvm/yvm-exec.js:1:172)
    at /home/circleci/.yvm/yvm-exec.js:1:964
    at Object.<anonymous> (/home/circleci/.yvm/yvm-exec.js:1:974)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
Makefile:120: recipe for target 'node_modules' failed
make: *** [node_modules] Error 1
Exited with code 2
```

This fixes that.