### PR TITLE
List remote should show installed versions

### DIFF
--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,22 +1,11 @@
-const fs = require('fs')
-
 const log = require('../util/log')
-const { stripVersionPrefix, versionRootPath } = require('../util/utils')
-const { getVersionInUse, printVersions } = require('../util/version')
-const { yvmPath } = require('../util/path')
+const {
+    getVersionInUse,
+    getYarnVersions,
+    printVersions,
+} = require('../util/version')
 
-const getYarnVersions = rootPath => {
-    const re = /^v(\d+\.)(\d+\.)(\d+)$/
-    if (fs.existsSync(versionRootPath(rootPath))) {
-        return fs
-            .readdirSync(versionRootPath(rootPath))
-            .filter(file => re.test(file))
-            .map(stripVersionPrefix)
-    }
-    return []
-}
-
-const listVersions = (rootPath = yvmPath) => {
+const listVersions = rootPath => {
     const installedVersions = getYarnVersions(rootPath)
     if (installedVersions.length) {
         getVersionInUse().then(versionInUse => {

--- a/src/commands/listRemote.js
+++ b/src/commands/listRemote.js
@@ -1,17 +1,25 @@
 const log = require('../util/log')
 const { getVersionsFromTags } = require('../util/utils')
-const { printVersions, getVersionInUse } = require('../util/version')
+const {
+    getVersionInUse,
+    getYarnVersions,
+    printVersions,
+} = require('../util/version')
 
 const listRemoteCommand = () => {
     log.info('list-remote')
-
-    return Promise.all([getVersionsFromTags(), getVersionInUse()])
+    return Promise.all([
+        getVersionsFromTags(),
+        getVersionInUse(),
+        getYarnVersions(),
+    ])
         .then(results => {
-            const [remoteVersions, versionInUse] = results
+            const [remoteVersions, versionInUse, localVersions] = results
             printVersions({
                 list: remoteVersions,
                 message: 'Versions available for install:',
                 versionInUse,
+                localVersions,
             })
         })
         .catch(error => log(error))

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -80,10 +80,11 @@ function getVersionInUse() {
 
 function getYarnVersions(yvmPath = defaultYvmPath) {
     const versionsPath = versionRootPath(yvmPath)
+    const prefixedVersionRegex = new RegExp(`^v${VERSION_REGEX.source}`)
     if (fs.existsSync(versionsPath)) {
         const files = fs.readdirSync(versionsPath)
         return files
-            .filter(name => name.startsWith('v') && isValidVersionString(name))
+            .filter(name => prefixedVersionRegex.test(name))
             .map(stripVersionPrefix)
     }
     return []

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -7,6 +7,8 @@ const log = require('./log')
 const { yvmPath: defaultYvmPath } = require('./path')
 const { stripVersionPrefix, versionRootPath } = require('./utils')
 const DEFAULT_VERSION_TEXT = 'Global Default'
+const VERSION_IN_USE_SYMBOL = '\u2713'
+const VERSION_INSTALLED_SYMBOL = '\u2192'
 
 function isValidVersionString(version) {
     return /\d+(\.\d+){2}(.*)/.test(version)
@@ -147,8 +149,8 @@ const printVersions = ({
         const isInstalled = localVersions.includes(version)
 
         let toLog = ' '
-        if (isCurrent) toLog += '\u2713'
-        else if (isInstalled) toLog += '\u2192'
+        if (isCurrent) toLog += VERSION_IN_USE_SYMBOL
+        else if (isInstalled) toLog += VERSION_INSTALLED_SYMBOL
         else toLog += '-'
         toLog += ` ${versionPadded}`
 
@@ -165,6 +167,9 @@ const printVersions = ({
 }
 
 module.exports = {
+    DEFAULT_VERSION_TEXT,
+    VERSION_IN_USE_SYMBOL,
+    VERSION_INSTALLED_SYMBOL,
     getRcFileVersion,
     getSplitVersionAndArgs,
     getDefaultVersion,

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -6,16 +6,18 @@ const cosmiconfig = require('cosmiconfig')
 const log = require('./log')
 const { yvmPath: defaultYvmPath } = require('./path')
 const { stripVersionPrefix, versionRootPath } = require('./utils')
+
 const DEFAULT_VERSION_TEXT = 'Global Default'
+const VERSION_REGEX = /\d+(\.\d+){2}(.*)/
 const VERSION_IN_USE_SYMBOL = '\u2713'
 const VERSION_INSTALLED_SYMBOL = '\u2192'
 
 function isValidVersionString(version) {
-    return /\d+(\.\d+){2}(.*)/.test(version)
+    return VERSION_REGEX.test(version)
 }
 
 function getValidVersionString(version) {
-    const parsedVersionString = version.match(/\d+(\.\d+){2}(.*)/)
+    const parsedVersionString = version.match(VERSION_REGEX)
     return parsedVersionString ? parsedVersionString[0] : null
 }
 
@@ -79,9 +81,10 @@ function getVersionInUse() {
 function getYarnVersions(yvmPath = defaultYvmPath) {
     const versionsPath = versionRootPath(yvmPath)
     if (fs.existsSync(versionsPath)) {
-        const re = /^v(\d+\.)(\d+\.)(\d+)$/
         const files = fs.readdirSync(versionsPath)
-        return files.filter(file => re.test(file)).map(stripVersionPrefix)
+        return files
+            .filter(name => name.startsWith('v') && isValidVersionString(name))
+            .map(stripVersionPrefix)
     }
     return []
 }

--- a/test/commands/listRemote.test.js
+++ b/test/commands/listRemote.test.js
@@ -4,15 +4,19 @@ const { getVersionInUse, printVersions } = require('../../src/util/version')
 
 jest.mock('../../src/util/version', () => {
     const MOCK_CURRENT_VERSION = '1.0.0'
+    const MOCK_LOCAL_VERSIONS = ['1.0.0', '1.6.0']
     return {
         getVersionInUse: jest.fn().mockImplementation(() => {
             return Promise.resolve(MOCK_CURRENT_VERSION)
+        }),
+        getYarnVersions: jest.fn().mockImplementation(() => {
+            return MOCK_LOCAL_VERSIONS
         }),
         printVersions: jest.fn(),
     }
 })
 jest.mock('../../src/util/utils', () => {
-    const MOCK_REMOTE_VERSIONS = ['1.0.0', '1.6.0']
+    const MOCK_REMOTE_VERSIONS = ['1.0.0', '1.6.0', '1.7.0']
     return {
         getVersionsFromTags: jest.fn().mockImplementation(() => {
             return Promise.resolve(MOCK_REMOTE_VERSIONS)
@@ -26,7 +30,8 @@ describe('yvm list-remote', () => {
             expect(getVersionInUse).toHaveBeenCalled()
             expect(getVersionsFromTags).toHaveBeenCalled()
             const callArgs = printVersions.mock.calls[0][0]
-            expect(callArgs.list).toEqual(['1.0.0', '1.6.0'])
+            expect(callArgs.list).toEqual(['1.0.0', '1.6.0', '1.7.0'])
+            expect(callArgs.localVersions).toEqual(['1.0.0', '1.6.0'])
             expect(callArgs.versionInUse).toEqual('1.0.0')
         })
     })

--- a/test/util/utils.test.js
+++ b/test/util/utils.test.js
@@ -1,11 +1,14 @@
-const { printVersions } = require('../../src/util/version')
+const {
+    DEFAULT_VERSION_TEXT,
+    VERSION_IN_USE_SYMBOL,
+    VERSION_INSTALLED_SYMBOL,
+    printVersions,
+} = require('../../src/util/version')
 
-const DEFAULT_VERSION_TEXT = 'Global Default'
-const VERSION_IN_USE_SYMBOL = `\u2713`
-
-const versions = ['1.1.0', '1.2.0', '1.3.0']
 const versionInUse = '1.2.0'
 const defaultVersion = '1.3.0'
+const localVersions = ['1.1.0', versionInUse, defaultVersion]
+const versions = [...localVersions, '1.4.0', '1.5.0']
 
 describe('Util functions', () => {
     it('Returns same number of versions passed to printVersion function', () => {
@@ -19,7 +22,7 @@ describe('Util functions', () => {
         expect(versionsObject[versionInUse]).toContain(VERSION_IN_USE_SYMBOL)
     })
 
-    it('Highlights the  default version', () => {
+    it('Highlights the default version', () => {
         const versionsObject = printVersions({
             list: versions,
             versionInUse,
@@ -27,5 +30,20 @@ describe('Util functions', () => {
         })
         expect(versionsObject[defaultVersion]).toBeDefined()
         expect(versionsObject[defaultVersion]).toContain(DEFAULT_VERSION_TEXT)
+    })
+
+    it('Highlights all installed versions', () => {
+        const versionsObject = printVersions({
+            list: versions,
+            versionInUse,
+            defaultVersion,
+            localVersions,
+        })
+        localVersions
+            .filter(v => v !== versionInUse)
+            .forEach(v => {
+                expect(versionsObject[v]).toBeDefined()
+                expect(versionsObject[v]).toContain(VERSION_INSTALLED_SYMBOL)
+            })
     })
 })

--- a/test/util/version.test.js
+++ b/test/util/version.test.js
@@ -1,9 +1,11 @@
 const mockFS = require('mock-fs')
+const { stripVersionPrefix } = require('../../src/util/utils')
 const {
     getDefaultVersion,
     setDefaultVersion,
     isValidVersionString,
     getValidVersionString,
+    getYarnVersions,
 } = require('../../src/util/version')
 
 describe('yvm default version', () => {
@@ -47,5 +49,24 @@ describe('yvm valid version', () => {
         expect(getValidVersionString('1.9.0')).toBe('1.9.0')
         expect(getValidVersionString('v1.9.0')).toBe('1.9.0')
         expect(getValidVersionString('v1.1.0-exp.2')).toBe('1.1.0-exp.2')
+    })
+})
+
+describe('yvm installed versions', () => {
+    const mockValid = ['v1.1.1', 'v1.2.3', 'v12.11.10-test-b2']
+    const mockInvalid = ['v1.0', 'v1.0-a', '1.1.2']
+    const mockYVMDir = '/mock-yvm-root-dir'
+    const mockYVMDirContents = {
+        versions: [...mockValid, ...mockInvalid].reduce(
+            (a, v) => Object.assign(a, { [v]: {} }),
+            {},
+        ),
+    }
+    beforeEach(() => mockFS({ [mockYVMDir]: mockYVMDirContents }))
+    afterEach(mockFS.restore)
+
+    it('Valid version folders', () => {
+        const expectedVersions = mockValid.map(stripVersionPrefix)
+        expect(getYarnVersions(mockYVMDir)).toEqual(expectedVersions)
     })
 })

--- a/test/util/version.test.js
+++ b/test/util/version.test.js
@@ -54,7 +54,7 @@ describe('yvm valid version', () => {
 
 describe('yvm installed versions', () => {
     const mockValid = ['v1.1.1', 'v1.2.3', 'v12.11.10-test-b2']
-    const mockInvalid = ['v1.0', 'v1.0-a', '1.1.2']
+    const mockInvalid = ['v1.0', 'v1.0-a', '1.1.2', 'va1.1.3']
     const mockYVMDir = '/mock-yvm-root-dir'
     const mockYVMDirContents = {
         versions: [...mockValid, ...mockInvalid].reduce(


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
Should resolve #272. 

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- `make install-watch`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- `yvm ls-remote`
  - should highlight all installed versions, including current and default
- `yvm ls`
  - should show only installed versions, highlighting current and default

### Comments:
<!-- Any other comments you want to include for reviewers. -->
- Opted to use a symbol and color instead of text to indicated installed versions

