### PR TITLE
fix: invalid version number when running `yvm use` to auto-install version from `.yvmrc` file

### DIFF
--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -167,7 +167,7 @@ const ensureVersionInstalled = (version, rootPath = yvmPath) => {
     if (fs.existsSync(yarnBinDir)) {
         return Promise.resolve()
     }
-    return installVersion(version, rootPath)
+    return installVersion({ version, rootPath })
 }
 
 module.exports = {


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->

- On a fresh install of YVM, when I was running `yvm use` in a project that had a `.yvmrc` file, I expected it to auto-install the version and it failed instead
- After tracing the code path, I discovered that `installVersion` was being called with incorrect arguments


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

- Run `make install`
- Create a folder with a `.yvmrc` file
- In the rc file, put a version number that you don't already have installed
- Run `yvm use`
- Verify that it downloads and installs the specified Yarn version and enables it

### Comments:
<!-- Any other comments you want to include for reviewers. -->


