### PR TITLE
feat: pipe sidio/stdout/stdin correctly between spawned yarn and parent

### DIFF
--- a/src/yvm-exec.js
+++ b/src/yvm-exec.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { exec } = require('shelljs')
+const childProcess = require('child_process')
 
 const { ensureVersionInstalled } = require('./commands/install')
 const { getSplitVersionAndArgs } = require('./util/version')
@@ -15,8 +15,17 @@ const runYarn = (version, extraArgs, rootPath) => {
     const filePath = path.resolve(getYarnPath(version, rootPath), 'bin/yarn.js')
     const command = `${filePath} ${extraArgs.join(' ')}`
     log.info(command)
-    const runTime = exec(command)
-    if (runTime.code !== 0) {
+    try {
+        // WARNING :: When changing this logic ensure that passing of stdio works correctly. e.g. user input, arrows keys
+        // test:
+        // `nvm use 4.8.0` (lowest supported node version
+        // `make install`
+        // `yvm exec contributors:add` and go through the steps
+        childProcess.execFileSync(filePath, extraArgs, {
+            stdio: 'inherit',
+        })
+    } catch (error) {
+        log(error.message)
         throw new Error('yarn failed, non-zero exit')
     }
 }


### PR DESCRIPTION
## Description
Use native child process over shelljs exec
Fixes #286



### DevQA Steps
FAIL case:
- Install latest
- `yvm exec contributors:add`
- See input fail (and arrow keys)

PASS case:
- Check out this branch
- `make install`
- `yvm exec contributors:add`
- See input succeed (and arrow keys work!)


