### PR TITLE
feat: fish shell compatible

### DIFF
--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -51,10 +51,11 @@ yvm_() {
     fi
 }
 
+yvm() {
+    yvm_ 'function' $@
+}
+
 if [ ${interactive} = 1 ]; then
-    yvm() {
-        yvm_ 'function' $@
-    }
     if ! type "node" > /dev/null; then
         yvm_err "YVM Could not find node executable."
         yvm_err "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bashrc"
@@ -63,6 +64,6 @@ if [ ${interactive} = 1 ]; then
     if [ "x" != "x${DEFAULT_YARN_VERSION}" ]; then
         yvm_use > /dev/null
     fi
-else
+elif [ -n "$*" ]; then
     yvm_ 'script' $@
 fi


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Move `yvm` shell function definition out of interactive block
- If running as script do nothing when no arguments passed

This allows sourcing of `yvm` using `bass`

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Have `fish` shell
  - `$ brew install fish`
- Install [`edc/bass`](https://github.com/edc/bass)
- Please `make install-watch`, this PR uses a new package

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- In fish shell create wrapper function
```fish
function yvm
    bass . $YVM_DIR/yvm.sh ';' yvm $argv
end
```
- Run `yvm use 1.13.0`
- Should work as in bash shell

### Comments:
<!-- Any other comments you want to include for reviewers. -->
- Stop gap solution for fish shell users until #273 is merged. See https://github.com/tophat/yvm/issues/116#issuecomment-456819295.
- Similar technique recommended for using `nvm` in `fish` shell
