### PR TITLE
feat: remove shelljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "openpgp": "^4.3.0",
     "request": "^2.87.0",
     "semver": "^5.6.0",
-    "shelljs": "^0.8.2",
     "targz": "^1.0.1"
   },
   "devDependencies": {

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -1,21 +1,16 @@
 const fs = require('fs-extra')
-const shell = require('shelljs')
 
 const { getExtractionPath } = require('../util/utils')
+const { getVersionInUse } = require('../util/version')
 const { yvmPath } = require('../util/path')
 
 const log = require('../util/log')
 
-const removeVersion = (version, rootPath = yvmPath) => {
+const removeVersion = async (version, rootPath = yvmPath) => {
     const versionPath = getExtractionPath(version, rootPath)
-    const { stdout, stderr, code } = shell.which('yarn')
+    const versionInUse = await getVersionInUse()
 
-    if (code !== 0) {
-        log(stderr)
-        return 2
-    }
-
-    if (stdout.startsWith(versionPath)) {
+    if (versionPath.includes(versionInUse)) {
         log('You cannot remove currently-active version')
         return 1
     }

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -10,7 +10,7 @@ const removeVersion = async (version, rootPath = yvmPath) => {
     const versionPath = getExtractionPath(version, rootPath)
     const versionInUse = await getVersionInUse()
 
-    if (versionPath.includes(versionInUse)) {
+    if (versionInUse && versionPath.includes(versionInUse)) {
         log('You cannot remove currently-active version')
         return 1
     }

--- a/src/commands/which.js
+++ b/src/commands/which.js
@@ -7,23 +7,23 @@ const log = require('../util/log')
 const { versionRootPath } = require('../util/utils')
 const { yvmPath } = require('../util/path')
 
-const whichCommand = (inputPath, testPath = '') => {
-    if (!getVersionInUse()) {
-        log('Sorry, yarn in NOT installed.')
+const whichCommand = async path => {
+    const versionInUse = await getVersionInUse()
+    if (!versionInUse) {
+        log('Sorry, yarn is NOT installed.')
         return 1
     }
-    const envPath = inputPath || process.env.PATH
+    const envPath = path || process.env.PATH
     if (envPath === null || envPath === '') {
+        log('Environment PATH not found.')
         return 1
     }
-
-    const yvmPathToUse = testPath ? testPath : yvmPath
 
     let foundVersion = false
 
     const pathVariables = envPath.split(':')
     pathVariables.forEach(element => {
-        if (element.startsWith(versionRootPath(yvmPathToUse))) {
+        if (element.startsWith(versionRootPath(yvmPath))) {
             const [pathVersion] = element
                 .split('/')
                 .map(getValidVersionString)

--- a/src/commands/which.js
+++ b/src/commands/which.js
@@ -1,13 +1,16 @@
-const shell = require('shelljs')
-const { getRcFileVersion, getValidVersionString } = require('../util/version')
+const {
+    getRcFileVersion,
+    getValidVersionString,
+    getVersionInUse,
+} = require('../util/version')
 const log = require('../util/log')
 const { versionRootPath } = require('../util/utils')
 const { yvmPath } = require('../util/path')
 
 const whichCommand = (inputPath, testPath = '') => {
-    if (!shell.which('yarn')) {
-        shell.echo('Sorry, yarn in NOT installed.')
-        shell.exit(1)
+    if (!getVersionInUse()) {
+        log('Sorry, yarn in NOT installed.')
+        return 1
     }
     const envPath = inputPath || process.env.PATH
     if (envPath === null || envPath === '') {

--- a/src/commands/which.js
+++ b/src/commands/which.js
@@ -14,7 +14,7 @@ const whichCommand = async path => {
         return 1
     }
     const envPath = path || process.env.PATH
-    if (envPath === null || envPath === '') {
+    if (!envPath) {
         log('Environment PATH not found.')
         return 1
     }

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const semver = require('semver')
-const { exec } = require('shelljs')
+const { execSync } = require('child_process')
 const cosmiconfig = require('cosmiconfig')
 
 const log = require('./log')
@@ -92,17 +92,13 @@ function getRcFileVersion() {
     return String(result.config)
 }
 
-function getVersionInUse() {
-    return new Promise(resolve => {
-        exec(
-            'yarn --version',
-            { async: true, silent: true },
-            (code, stdout) => {
-                const versionInUse = stdout
-                resolve(versionInUse)
-            },
-        )
-    })
+async function getVersionInUse() {
+    try {
+        return String(execSync('yarn --version')).trim()
+    } catch (error) {
+        log.info(error)
+        return ''
+    }
 }
 
 function getYarnVersions(yvmPath = defaultYvmPath) {

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -73,10 +73,10 @@ argParser
     .description(
         'Display path to installed yarn version. Uses .yvmrc if available.',
     )
-    .action(() => {
+    .action(async () => {
         log.info('Checking yarn version')
         const which = require('./commands/which')
-        process.exit(which())
+        process.exit(await which())
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -51,10 +51,10 @@ argParser
     .command('remove <version>')
     .alias('rm')
     .description('Uninstall the specified version of Yarn.')
-    .action(version => {
+    .action(async version => {
         log.info(`Removing yarn v${version}`)
         const remove = require('./commands/remove')
-        process.exit(remove(version))
+        process.exit(await remove(version))
     })
 
 // commander has support for sub commands, and will load the file yvm-exec when this is run

--- a/test/commands/remove.test.js
+++ b/test/commands/remove.test.js
@@ -1,10 +1,15 @@
+const path = require('path')
 const fs = require('fs-extra')
 
-const remove = require('../../src/commands/remove')
 const { getExtractionPath, versionRootPath } = require('../../src/util/utils')
+const version = require('../../src/util/version')
+const getVersionInUse = jest.spyOn(version, 'getVersionInUse')
+const remove = require('../../src/commands/remove')
 
 describe('yvm remove', () => {
     const rootPath = '/tmp/yvmRemove'
+    const versionRoot = versionRootPath(rootPath)
+    const versionPath = version => path.resolve(versionRoot, `v${version}`)
 
     beforeAll(() => {
         fs.mkdirsSync(rootPath)
@@ -12,15 +17,24 @@ describe('yvm remove', () => {
 
     afterEach(() => {
         fs.removeSync(versionRootPath(rootPath))
+        getVersionInUse.mockReset()
     })
 
-    it('Removes installed version specified', () => {
+    it('Removes installed version specified', async () => {
         const version = '1.7.0'
+        getVersionInUse.mockReturnValue('')
         const versionInstallationPath = getExtractionPath(version, rootPath)
         fs.mkdirsSync(versionInstallationPath)
-        remove(version, rootPath)
-        expect(
-            fs.readdirSync(versionRootPath(rootPath)).indexOf(`v${version}`),
-        ).toBe(-1)
+        expect(await remove(version, rootPath)).toBe(0)
+        expect(fs.existsSync(versionPath(version))).toBe(false)
+    })
+
+    it('Does not removes currently active version', async () => {
+        const version = '1.7.0'
+        getVersionInUse.mockReturnValue(version)
+        const versionInstallationPath = getExtractionPath(version, rootPath)
+        fs.mkdirsSync(versionInstallationPath)
+        expect(await remove(version, rootPath)).toBe(1)
+        expect(fs.existsSync(versionPath(version))).toBe(true)
     })
 })

--- a/test/commands/which.test.js
+++ b/test/commands/which.test.js
@@ -25,6 +25,15 @@ describe('yvm which command', () => {
             expect.stringContaining(`yarn is NOT installed`),
         )
     })
+    it('fails if environment path is not available', async () => {
+        const oldPath = process.env.PATH
+        delete process.env.PATH
+        expect(await which()).toBe(1)
+        expect(log).toHaveBeenCalledWith(
+            expect.stringContaining(`PATH not found`),
+        )
+        process.env.PATH = oldPath
+    })
     it('fails to find yarn version if yvm not installed', async () => {
         const path = '/Users/tophat/.nvm/versions/node/v6.11.5/bin:'
         expect(await which(path)).toBe(2)

--- a/test/commands/which.test.js
+++ b/test/commands/which.test.js
@@ -1,4 +1,10 @@
 const fs = require('fs')
+const path = require('../../src/util/path')
+path.yvmPath = '/Users/tophat/.yvm'
+const version = require('../../src/util/version')
+const getVersionInUse = jest
+    .spyOn(version, 'getVersionInUse')
+    .mockResolvedValue('1.7.0')
 const which = require('../../src/commands/which')
 const log = require('../../src/util/log')
 
@@ -6,31 +12,37 @@ jest.mock('../../src/util/log')
 
 describe('yvm which command', () => {
     afterEach(() => {
-        jest.resetModules()
+        jest.clearAllMocks()
     })
     afterAll(() => {
         jest.restoreAllMocks()
     })
-    it('fails to find yarn version if none installed', () => {
+    it('fails if yarn not installed and active', async () => {
+        getVersionInUse.mockResolvedValueOnce('')
         const path = '/Users/tophat/.nvm/versions/node/v6.11.5/bin:'
-        expect(which(path)).toBe(2)
+        expect(await which(path)).toBe(1)
+        expect(log).toHaveBeenCalledWith(
+            expect.stringContaining(`yarn is NOT installed`),
+        )
+    })
+    it('fails to find yarn version if yvm not installed', async () => {
+        const path = '/Users/tophat/.nvm/versions/node/v6.11.5/bin:'
+        expect(await which(path)).toBe(2)
         expect(log).toHaveBeenCalledWith(
             expect.stringContaining(`don't have yvm version installed`),
         )
     })
-    it('Succeeds if yvm version matches .yvmrc', () => {
+    it('Succeeds if yvm version matches .yvmrc', async () => {
         const version = fs.readFileSync('.yvmrc', 'utf8')
         const path = `/Users/tophat/.yvm/versions/v${version}/bin:`
-        const testPath = '/Users/tophat/.yvm'
-        expect(which(path, testPath)).toBe(0)
+        expect(await which(path)).toBe(0)
         expect(log).toHaveBeenCalledWith(
             expect.stringContaining(`version matches your PATH version`),
         )
     })
-    it('Succeeds if yvm version does not match .yvmrc', () => {
+    it('Succeeds if yvm version does not match .yvmrc', async () => {
         const path = '/Users/tophat/.yvm/versions/v0.0.0/bin:'
-        const testPath = '/Users/tophat/.yvm'
-        expect(which(path, testPath)).toBe(0)
+        expect(await which(path)).toBe(0)
         expect(log).toHaveBeenCalledWith(expect.stringContaining(`don't match`))
     })
 })

--- a/test/util/version.test.js
+++ b/test/util/version.test.js
@@ -1,4 +1,6 @@
 const mockFS = require('mock-fs')
+const childProcess = require('child_process')
+const execSync = jest.spyOn(childProcess, 'execSync')
 const log = require('../../src/util/log')
 const path = require('../../src/util/path')
 const { stripVersionPrefix } = require('../../src/util/utils')
@@ -7,6 +9,7 @@ const {
     getSplitVersionAndArgs,
     getValidVersionString,
     getVersionFromRange,
+    getVersionInUse,
     getYarnVersions,
     isValidVersionRange,
     isValidVersionString,
@@ -148,5 +151,19 @@ describe('yvm installed versions', () => {
     it('Valid version folders', () => {
         const expectedVersions = mockValid.map(stripVersionPrefix)
         expect(getYarnVersions(mockYVMDir)).toEqual(expectedVersions)
+    })
+})
+
+describe('yarn version in use', () => {
+    it('gets active version', async () => {
+        execSync.mockReturnValueOnce('  1.7.0  ')
+        expect(await getVersionInUse()).toEqual('1.7.0')
+    })
+
+    it('returns empty string on failure', async () => {
+        execSync.mockImplementationOnce(() => {
+            throw 'some error'
+        })
+        expect(await getVersionInUse()).toEqual('')
     })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,7 +4244,7 @@ inquirer@^6.2.0:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
-interpret@^1.0.0, interpret@^1.1.0:
+interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
@@ -7411,12 +7411,6 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
-
 redent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
@@ -7648,7 +7642,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -7914,14 +7908,6 @@ shebang-regex@^1.0.0:
 shelljs@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
-
-shelljs@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Removed shelljs dependency
- Updates remove logic to use `yarn --version` to check version in use
- Adds tests


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Please `make install-watch`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- `yvm i 1.8.0`
- `yvm ls` confirm version is listed
- `yvm rm 1.8.0` should remove version successfully
- `yvm ls` confirm version not listed
- `yvm use 1.13.0`
- `yvm ls` confirm version listed
- `yvm rm 1.13.0` should not remove version
- `yvm ls` confirm version still listed
- `yarn --version` confirm version still active


### Comments:
<!-- Any other comments you want to include for reviewers. -->
- Addresses comments from #290

