### PR TITLE
feat: use yarn engine in package json

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Yarn Version Manager
 
 Pesky yarn versions got you down? Automatically and easilly manage those versions.
 
-YVM will automatically use the correct yarn version when you run any yarn commands in any folder with a `.yvmrc` file. Otherwise, it will use you a globally set version of yarn.
+YVM will automatically use the correct yarn version when you run any yarn commands in any folder with a `package.json`, `.yvmrc` or any other [supported configuration](https://yvm.js.org/docs/faq#declare-yvm-version-in-a-configuration-file-where-can-i-place-my-version-number) file. Otherwise, it will use you a globally set version of yarn.
 
 
 ## Motivation
@@ -86,6 +86,13 @@ Finally, add the following lines to your `$HOME/.zshrc` or `$HOME/.bashrc`, depe
 ```bash
 export YVM_DIR=/home/joe_user/.yvm
 [ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh
+```
+
+And in your `$HOME/.config/fish/config.fish` for fishers:
+
+```fish
+set -x YVM_DIR /home/joe_user/.yvm
+. $YVM_DIR/yvm.fish
 ```
 
 ### Upgrade
@@ -141,8 +148,9 @@ Full list of available commands
 yvm help
 ```
 
-### Using a .yvmrc File
-You can create a `.yvmrc` file containing the version number of yarn in your project's root directory. Afterwards, `yvm use`, `yvm install` and `yvm exec` will use the version specified in the `.yvmrc` file if no version number is supplied to the command.
+### Configuration file
+
+Yvm defaults to using the `yarn` version in your `package.json` `engines`. Otherwise you can create a `.yvmrc` file containing the version number of yarn in your project's root directory. Afterwards, `yvm use`, `yvm install` and `yvm exec` will use the version specified in the config file if no version number is supplied to the command.
 You can also [declare the version using other configuration files](https://yvm.js.org/docs/faq#declare-yvm-version-in-a-configuration-file-where-can-i-place-my-version-number)
 
 ### Additional reference
@@ -165,6 +173,13 @@ export YVM_DIR=/home/joe_user/.yvm
 [ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh
 ```
 
+Remove in `$HOME/.config/fish/config.fish` for fishers:
+
+```fish
+set -x YVM_DIR /home/joe_user/.yvm
+. $YVM_DIR/yvm.fish
+```
+
 In case you had older version of yvm installed, there could also be a line like
 
 ```bash
@@ -184,10 +199,10 @@ We welcome contributions from the community, Top Hatters and non-Top Hatters ali
 ### Basic development flow
 
 1. Ensure the problem you are solving [is an issue](https://github.com/tophat/yvm/issues) or you've created one
-1. Clone the repo
-1. We use make. `make help` will show you a list of development commands
-1. `make install-watch` will install yvm on your shell, update when you make changes, and automatically source yvm.sh. Make sure to only run this in the root yvm directory. It will fail elsewhere.
-1. `make test` and `make lint` are also commonly helpful
+2. Clone the repo
+3. We use make. `make help` will show you a list of development commands
+4. `make install-watch` will install yvm on your shell, update when you make changes, and automatically source yvm.sh. Make sure to only run this in the root yvm directory. It will fail elsewhere.
+5. `make test` and `make lint` are also commonly helpful
 
 Make sure all changes are well documented. Our documentation can be found inside the `docs` section of this repo. Be sure to read it carefully and make modifications wherever necessary.
 You can also access the documentation on our [website](https://yvm.js.org)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,5 +20,5 @@ Try opening another terminal window, or type `source ~/.yvm/yvm.sh`.
 
 
 ## Declare yvm version in a configuration file. Where can I place my version number?
-You can set your version number in your `package.json` under the key `yvm` or in any file named: `.yvmrc`, `.yvmrc.json`, `.yvmrc.yaml`, `.yvmrc.yml`, `.yvmrc.js`, or `yvm.config.js`.
+You can set your version number or [range](https://semver.org/) in your `package.json` `engines.yarn` prop or in any file named: `.yvmrc`, `.yvmrc.json`, `.yvmrc.yaml`, `.yvmrc.yml`, `.yvmrc.js`, or `yvm.config.js`.
 The files will be searched in the current directory, and then up the tree.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/polyfill": "^7.0.0",
     "chalk": "^2.4.2",
     "commander": "^2.15.1",
-    "cosmiconfig": "^5.0.5",
+    "cosmiconfig": "^5.1.0",
     "fs-extra": "^7.0.1",
     "openpgp": "^4.3.0",
     "request": "^2.87.0",

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -28,11 +28,22 @@ function getValidVersionString(version) {
     return semver.clean(version)
 }
 
+/**
+ * Get the most recent yarn install version in the specified range
+ * @param {String} versionRange the bounding yarn version range
+ * @throws if no install version can be found for range
+ */
 async function getVersionFromRange(versionRange) {
-    return (
+    const availableVersion =
         semver.maxSatisfying(getYarnVersions(), versionRange) ||
         semver.maxSatisfying(await getVersionsFromTags(), versionRange)
-    )
+    if (!availableVersion) {
+        throw new Error(
+            `Given version range can not be satisfied by yarn: ${versionRange}
+See list of available yarn versions using: 'yvm list-remote'`,
+        )
+    }
+    return availableVersion
 }
 
 function getDefaultVersion(yvmPath = defaultYvmPath) {

--- a/test/util/__snapshots__/version.test.js.snap
+++ b/test/util/__snapshots__/version.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`yvm valid version Does not accept version range ^0.1.0 1`] = `
+[Error: Given version range can not be satisfied by yarn: ^0.1.0
+See list of available yarn versions using: 'yvm list-remote']
+`;
+
+exports[`yvm valid version Does not accept version range ~1.0.9 1`] = `
+[Error: Given version range can not be satisfied by yarn: ~1.0.9
+See list of available yarn versions using: 'yvm list-remote']
+`;
+
+exports[`yvm valid version Does not accept version range ~1.7.1 1`] = `
+[Error: Given version range can not be satisfied by yarn: ~1.7.1
+See list of available yarn versions using: 'yvm list-remote']
+`;
+
+exports[`yvm valid version Does not accept version range ~1.12.4 1`] = `
+[Error: Given version range can not be satisfied by yarn: ~1.12.4
+See list of available yarn versions using: 'yvm list-remote']
+`;

--- a/test/util/version.test.js
+++ b/test/util/version.test.js
@@ -134,23 +134,17 @@ describe('yvm valid version', () => {
         expect(await getVersionFromRange('>=1.10.0 < 1.13')).toBe('1.12.3')
     })
 
-    it('Does not accept version range', done => {
-        const failOnSuccessFor = range => version =>
-            done.fail(
-                `Should have thrown error for '${range}', got '${version}' instead`,
-            )
-        const validateErrorMessage = ({ message }) => {
-            expect(message).toContain('can not be satisfied by yarn')
-            expect(message).toContain('list of available yarn versions')
-        }
-        Promise.all(
-            ['^0.1.0', '~1.0.9', '~1.12.4', '~1.7.1'].map(range => {
-                getVersionFromRange(range)
-                    .then(failOnSuccessFor(range))
-                    .catch(validateErrorMessage)
-            }),
-        ).then(() => done())
-    })
+    it.each([['^0.1.0'], ['~1.0.9'], ['~1.12.4'], ['~1.7.1']])(
+        'Does not accept version range %s',
+        async range => {
+            try {
+                const version = await getVersionFromRange(range)
+                throw `Should have thrown error for '${range}', got '${version}' instead`
+            } catch (e) {
+                expect(e).toMatchSnapshot()
+            }
+        },
+    )
 })
 
 describe('yvm installed versions', () => {

--- a/test/util/version.test.js
+++ b/test/util/version.test.js
@@ -133,6 +133,24 @@ describe('yvm valid version', () => {
         expect(await getVersionFromRange('1.9')).toBe('1.9.4')
         expect(await getVersionFromRange('>=1.10.0 < 1.13')).toBe('1.12.3')
     })
+
+    it('Does not accept version range', done => {
+        const failOnSuccessFor = range => version =>
+            done.fail(
+                `Should have thrown error for '${range}', got '${version}' instead`,
+            )
+        const validateErrorMessage = ({ message }) => {
+            expect(message).toContain('can not be satisfied by yarn')
+            expect(message).toContain('list of available yarn versions')
+        }
+        Promise.all(
+            ['^0.1.0', '~1.0.9', '~1.12.4', '~1.7.1'].map(range => {
+                getVersionFromRange(range)
+                    .then(failOnSuccessFor(range))
+                    .catch(validateErrorMessage)
+            }),
+        ).then(() => done())
+    })
 })
 
 describe('yvm installed versions', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2282,12 +2282,14 @@ cosmiconfig@^5.0.1, cosmiconfig@^5.0.6:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
-cosmiconfig@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+cosmiconfig@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.1.0.tgz#6c5c35e97f37f985061cdf653f114784231185cf"
   dependencies:
+    import-fresh "^2.0.0"
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
+    lodash.get "^4.4.2"
     parse-json "^4.0.0"
 
 crc32-stream@^2.0.0:


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Bumps `cosmiconfig` dependency to support using nested `package.json` prop e.g. `engines.yarn`
- [x] Update documentation to reflect `yvm` support for the `package.json` configuration

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Please `make install-watch`, this PR uses an updated package

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- Set the `engines.yarn` property in a projects `package.json` to a valid semver range
- `yvm use` in the directory
- Yarn version in use should be one satisfying the value supplied

### Comments:
<!-- Any other comments you want to include for reviewers. -->
- Follow up to https://github.com/tophat/yvm/pull/291#discussion_r249913994
- Addresses comments in #284

