### PR TITLE
fix: init yvm function in non interactive shell

### DIFF
--- a/src/yvm.fish
+++ b/src/yvm.fish
@@ -34,7 +34,7 @@ function yvm
         node "$YVM_DIR/yvm.js" $argv
     end
 
-    function yvm_init_fish
+    function yvm_init_sh
         if not type -q "node"
             yvm_err "%s\n" "YVM Could not automatically set yarn version."
             yvm_err "%s\n" "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your fish config file"
@@ -55,11 +55,11 @@ function yvm
         end
     else if [ "$command" = "update-self" ]
         env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | bash
-    else if [ "$command" = "init-fish" ]
-        yvm_init_fish
+    else if [ "$command" = "init-sh" ]
+        yvm_init_sh
     else
         yvm_call_node_script $argv[1..-1]
     end
 end
 
-yvm init-fish
+yvm init-sh

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -1,68 +1,53 @@
 #!/bin/sh
-
-command=$1
 YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}
-export_yvm_dir_string="export YVM_DIR=${YVM_DIR}"
 
-yvm_use() {
-    local PROVIDED_VERSION=${1}
-    NEW_PATH=$(yvm_call_node_script get-new-path ${PROVIDED_VERSION})
-    if [ -z "${NEW_PATH}" ]; then
-        yvm_err "Could not get new path from yvm"
-    else
-        PATH=${NEW_PATH}
-        yvm_echo "Now using yarn version $(yarn --version)"
-    fi
-}
-
-yvm_echo() {
-    command printf %s\\n "$*" 2>/dev/null
-}
-
-yvm_err() {
-    >&2 yvm_echo "$@"
-}
-
-yvm_call_node_script() {
-    # do not add anything that outputs stuff to stdout in function, its output is stored in a variable
-    node "${YVM_DIR}/yvm.js" $@
-}
-
-case "$-" in
-    *i*) interactive=1;;
-    *) interactive=0;;
-esac
-
-yvm_() {
-    mode=$1
-    shift 1
-
+yvm() {
     command=$1
-    if [ "${command}" = "use" ]; then
-        if [ "${mode}" = 'script' ]; then
-            yvm_err '"yvm use" can only be used when yvm is a shell function, not a script. Did you forget to source yvm?'
-            exit 1
+
+    yvm_use() {
+        local PROVIDED_VERSION=${1}
+        NEW_PATH=$(yvm_call_node_script get-new-path ${PROVIDED_VERSION})
+        if [ -z "${NEW_PATH}" ]; then
+            yvm_err "Could not get new path from yvm"
+        else
+            PATH=${NEW_PATH}
+            yvm_echo "Now using yarn version $(yarn --version)"
         fi
+    }
+
+    yvm_echo() {
+        command printf %s\\n "$*" 2>/dev/null
+    }
+
+    yvm_err() {
+        >&2 yvm_echo "$@"
+    }
+
+    yvm_call_node_script() {
+        # do not add anything that outputs stuff to stdout in function, its output is stored in a variable
+        node "${YVM_DIR}/yvm.js" $@
+    }
+
+    yvm_init_sh() {
+        if ! type "node" > /dev/null; then
+            yvm_err "YVM Could not find node executable."
+            yvm_err "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bashrc"
+        fi
+        DEFAULT_YARN_VERSION=$(yvm_call_node_script get-default-version 2>/dev/null)
+        if [ "x" != "x${DEFAULT_YARN_VERSION}" ]; then
+            yvm_use > /dev/null
+        fi
+    }
+
+    if [ "${command}" = "use" ]; then
         yvm_use $2
     elif [ "${command}" = "update-self" ]; then
         curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash
+    elif [ "${command}" = "init-sh" ]; then
+        yvm_init_sh
     else
         yvm_call_node_script $@
     fi
 }
 
-if [ ${interactive} = 1 ]; then
-    yvm() {
-        yvm_ 'function' $@
-    }
-    if ! type "node" > /dev/null; then
-        yvm_err "YVM Could not find node executable."
-        yvm_err "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bashrc"
-    fi
-    DEFAULT_YARN_VERSION=$(yvm_call_node_script get-default-version 2>/dev/null)
-    if [ "x" != "x${DEFAULT_YARN_VERSION}" ]; then
-        yvm_use > /dev/null
-    fi
-else
-    yvm_ 'script' $@
-fi
+yvm init-sh

--- a/test/sanity-test.sh
+++ b/test/sanity-test.sh
@@ -1,7 +1,7 @@
-#!/bin/bash -e
+#!/bin/bash
 
 GREEN='\033[0;32m'
-RED='\031[0;32m'
+RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 
@@ -23,11 +23,10 @@ fail() {
 }
 
 source ~/.yvm/yvm.sh
-YVM=~/.yvm/yvm.sh
 
 testing "yvm exec version command"
-${YVM} install 1.11.0
-test1_output=$(${YVM} exec 1.11.0 --version)
+yvm install 1.11.0
+test1_output=$(yvm exec 1.11.0 --version)
 if [[ ${test1_output} == "1.11.0" ]]; then
     pass
 else
@@ -35,9 +34,9 @@ else
 fi
 
 testing "yvm use"
-${YVM} install 1.7.0
-yvm_use # in place of yvm use
-test2_output=$(${YVM} exec --version)
+yvm install 1.7.0
+yvm use
+test2_output=$(yvm exec --version)
 if [[ ${test2_output} == "1.7.0" ]]; then
     pass
 else


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
Should resolve #316
- Removes dependence on interactive mode
  - Refactor `yvm.sh` to function like `yvm.fish`

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Please `make install-watch`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- `yvm ls-remote` Should show list of available versions
- `bash --login -c 'yvm install <version>'` Any version from the list should work
- `yvm ls` Should show list of installed versions
- `bash --login -c 'yvm use <version>'` Any installed version should work
- `bash --login -c 'yvm exec --version'` Should show current yarn version
