### PR TITLE
fix: yarn version output

### DIFF
--- a/src/util/yvmInstalledVersion.js
+++ b/src/util/yvmInstalledVersion.js
@@ -15,8 +15,7 @@ const yvmInstalledVersion = (inYvmPath = yvmPath) => {
         }
         return version
     } catch (e) {
-        log('Unable to determine installed version')
-        log(e)
+        log.info(e)
         return undefined
     }
 }

--- a/test/util/__snapshots__/yvmInstalledVersion.test.js.snap
+++ b/test/util/__snapshots__/yvmInstalledVersion.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`yvm installed version logs reason for failure if verbose is true 1`] = `
+Array [
+  [Error: ENOENT: no such file or directory, open '/mock-yvm-root-dir/.version'],
+]
+`;

--- a/test/util/yvmInstalledVersion.test.js
+++ b/test/util/yvmInstalledVersion.test.js
@@ -1,9 +1,14 @@
 const mockFS = require('mock-fs')
+const log = require('../../src/util/log')
 const { yvmInstalledVersion } = require('../../src/util/yvmInstalledVersion')
 
 describe('yvm installed version', () => {
     const mockYVMDir = '/mock-yvm-root-dir'
+    jest.spyOn(log, 'default')
+
+    beforeEach(jest.clearAllMocks)
     afterEach(mockFS.restore)
+    afterAll(jest.restoreAllMocks)
 
     it('Finds version if installed', () => {
         const mockVersion = 'v1.2.3'
@@ -16,10 +21,13 @@ describe('yvm installed version', () => {
     })
 
     it('fails to find version if no file', () => {
+        delete process.env.YVM_VERBOSE
         expect(yvmInstalledVersion(mockYVMDir)).toBeUndefined()
+        expect(log.default).not.toHaveBeenCalled()
     })
 
     it('fails to find version if file does not contain valid json', () => {
+        delete process.env.YVM_VERBOSE
         const mockVersion = 'v1.2.3'
         mockFS({
             [mockYVMDir]: {
@@ -27,9 +35,11 @@ describe('yvm installed version', () => {
             },
         })
         expect(yvmInstalledVersion(mockYVMDir)).toBeUndefined()
+        expect(log.default).not.toHaveBeenCalled()
     })
 
     it('fails to find version if file does not valid json with "version" key', () => {
+        delete process.env.YVM_VERBOSE
         const mockVersion = 'v1.2.3'
         mockFS({
             [mockYVMDir]: {
@@ -37,5 +47,14 @@ describe('yvm installed version', () => {
             },
         })
         expect(yvmInstalledVersion(mockYVMDir)).toBeUndefined()
+        expect(log.default).not.toHaveBeenCalled()
+    })
+
+    it('logs reason for failure if verbose is true', () => {
+        process.env.YVM_VERBOSE = true
+        expect(yvmInstalledVersion(mockYVMDir)).toBeUndefined()
+        expect(log.default).toHaveBeenCalledTimes(1)
+        expect(log.default.mock.calls[0]).toMatchSnapshot()
+        delete process.env.YVM_VERBOSE
     })
 })


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
Should resolve #317
- Does not print error when attempting to get `yvm version`

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- uninstall yvm
- Please `make install`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- `yvm version` should show a regular message
- `YVM_VERBOSE=1 yvm version` should show reason for failure
