### PR TITLE
Preflight check on install dependencies

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@ INSTALL_DEPENDENCIES=( "unzip" "curl" )
 
 for package in "${INSTALL_DEPENDENCIES[@]}"
 do
-    if [ ! `eval "$package -v"` ]; then
+    if [ ! `eval "$package --version"` ]; then
         err_report_missing_dependency $package
         exit 1
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,7 @@ err_report_missing_dependency() {
 
 trap 'err_report $LINENO' ERR
 
-INSTALL_DEPENDENCIES=( "unzips" "curl" )
+INSTALL_DEPENDENCIES=( "unzip" "curl" )
 
 for package in "${INSTALL_DEPENDENCIES[@]}"
 do

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ err_report() {
 }
 
 err_report_missing_dependency() {
-    echo "The install cannot proceed due to a missing dependency. \"${1}\" is not installed."
+    echo "The install cannot proceed due to a missing dependency. \"${1}\" is not installed or available in your PATH."
 }
 
 trap 'err_report $LINENO' ERR

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@ INSTALL_DEPENDENCIES=( "unzip" "curl" )
 
 for package in "${INSTALL_DEPENDENCIES[@]}"
 do
-    if [ ! `eval "$package --version"` ]; then
+    if [ ! `eval "command -v $package"` ]; then
         err_report_missing_dependency $package
         exit 1
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,7 +6,21 @@ err_report() {
     echo "yvm failed to install, the command that failed was: https://github.com/tophat/yvm/blob/master/scripts/install.sh#L${1}"
 }
 
+err_report_missing_dependency() {
+    echo "The install cannot proceed due to a missing dependency. \"${1}\" is not installed."
+}
+
 trap 'err_report $LINENO' ERR
+
+INSTALL_DEPENDENCIES=( "unzips" "curl" )
+
+for package in "${INSTALL_DEPENDENCIES[@]}"
+do
+    if [ ! `eval "$package -v"` ]; then
+        err_report_missing_dependency $package
+        exit 1
+    fi
+done
 
 USE_LOCAL=${USE_LOCAL-false}
 


### PR DESCRIPTION
## Description
This PR adds pre-install checks to verify that all of the commands that the install process requires are installed and executable. In the case where it's not, it prints clear messaging about what package is missing and terminates the install process.

## DevQA

### DevQA Prep

### DevQA Steps
You can temporarily remove `unzip` or `curl` from your PATH (or QA inside a Docker container that doesn't have those packages) -- trying to run the install script in those conditions should trigger the preflight check with the appropriate message.

If you run the install script in an environment where both `curl` and `unzip` are well-defined, you should be allowed through normally.
