### PR TITLE
chore: standardize exit codes

### DIFF
--- a/src/commands/alias.js
+++ b/src/commands/alias.js
@@ -1,0 +1,54 @@
+import log from '../util/log'
+import { getFormatter, resolveMatchingAliases, setAlias } from '../util/alias'
+import {
+    getVersionInUse,
+    getYarnVersions,
+    resolveVersion,
+} from '../util/version'
+import { getVersionsFromTags } from '../util/utils'
+
+export const alias = async (nameOrPattern, maybeVersion) => {
+    try {
+        const format = getFormatter(
+            await getVersionsFromTags(),
+            getYarnVersions(),
+            await getVersionInUse(),
+        )
+
+        const safeResolveVersion = async versionString =>
+            resolveVersion({ versionString }).catch(e => log.info(e.message))
+
+        if (typeof maybeVersion === 'string') {
+            const name = nameOrPattern
+            const version = maybeVersion
+            let targetVersion
+            if (await setAlias({ name, version })) {
+                targetVersion = await safeResolveVersion(version)
+            }
+            const message = format(name, version, targetVersion)
+            if (targetVersion) {
+                log(message)
+                return 0
+            } else {
+                log.error(message)
+                return 1
+            }
+        } else {
+            const pattern = nameOrPattern || ''
+            const matchingAliases = await resolveMatchingAliases(pattern)
+            for (const {
+                name,
+                value: { value, version: versionString },
+            } of matchingAliases) {
+                const version = await safeResolveVersion(versionString)
+                log(format(name, value, version))
+            }
+            const noMatchFound =
+                pattern.length > 0 && matchingAliases.length < 1
+            return noMatchFound ? 1 : 0
+        }
+    } catch (e) {
+        log.error(e.message)
+        return 2
+    }
+}

--- a/src/commands/alias.js
+++ b/src/commands/alias.js
@@ -7,45 +7,63 @@ import {
 } from '../util/version'
 import { getVersionsFromTags } from '../util/utils'
 
+const safeResolveVersion = async versionString =>
+    resolveVersion({ versionString }).catch(e => log.info(e.message))
+
+const setAliasCommand = async ({ name, version }) => {
+    const [allVersions, installedVersions, currentVersion] = await Promise.all([
+        getVersionsFromTags(),
+        getYarnVersions(),
+        getVersionInUse(),
+    ])
+    const format = getFormatter(allVersions, installedVersions, currentVersion)
+    let targetVersion
+    if (await setAlias({ name, version })) {
+        targetVersion = await safeResolveVersion(version)
+    }
+    const message = format(name, version, targetVersion)
+    if (targetVersion) {
+        log(message)
+        return 0
+    } else {
+        log.error(message)
+        return 1
+    }
+}
+
+const getAliasCommand = async ({ pattern }) => {
+    const [
+        allVersions,
+        installedVersions,
+        currentVersion,
+        matchingAliases,
+    ] = await Promise.all([
+        getVersionsFromTags(),
+        getYarnVersions(),
+        getVersionInUse(),
+        resolveMatchingAliases(pattern),
+    ])
+    const format = getFormatter(allVersions, installedVersions, currentVersion)
+    for (const {
+        name,
+        value: { value, version: versionString },
+    } of matchingAliases) {
+        const version = await safeResolveVersion(versionString)
+        log(format(name, value, version))
+    }
+    const noMatchFound = pattern.length > 0 && matchingAliases.length < 1
+    return noMatchFound ? 1 : 0
+}
+
 export const alias = async (nameOrPattern, maybeVersion) => {
     try {
-        const format = getFormatter(
-            await getVersionsFromTags(),
-            getYarnVersions(),
-            await getVersionInUse(),
-        )
-
-        const safeResolveVersion = async versionString =>
-            resolveVersion({ versionString }).catch(e => log.info(e.message))
-
         if (typeof maybeVersion === 'string') {
             const name = nameOrPattern
             const version = maybeVersion
-            let targetVersion
-            if (await setAlias({ name, version })) {
-                targetVersion = await safeResolveVersion(version)
-            }
-            const message = format(name, version, targetVersion)
-            if (targetVersion) {
-                log(message)
-                return 0
-            } else {
-                log.error(message)
-                return 1
-            }
+            return await setAliasCommand({ name, version })
         } else {
             const pattern = nameOrPattern || ''
-            const matchingAliases = await resolveMatchingAliases(pattern)
-            for (const {
-                name,
-                value: { value, version: versionString },
-            } of matchingAliases) {
-                const version = await safeResolveVersion(versionString)
-                log(format(name, value, version))
-            }
-            const noMatchFound =
-                pattern.length > 0 && matchingAliases.length < 1
-            return noMatchFound ? 1 : 0
+            return await getAliasCommand({ pattern })
         }
     } catch (e) {
         log.error(e.message)

--- a/src/commands/exec.js
+++ b/src/commands/exec.js
@@ -9,27 +9,32 @@ import { yvmPath } from '../util/path'
 const getYarnPath = (version, rootPath) =>
     path.resolve(rootPath, `versions/v${version}`)
 
-const runYarn = (version, extraArgs = ['-v'], rootPath = yvmPath) => {
+/**
+ * __WARNING__
+ * When changing this logic ensure that passing of stdio works correctly.
+ * e.g. user input, arrows keys, etc.
+ *
+ * __TEST__
+ * - `nvm use 8.0.0` (lowest supported node version)
+ * - `make install`
+ * - `yvm exec contributors:add` and go through the steps
+ */
+const runYarn = (version, extraArgs, rootPath = yvmPath) => {
     process.argv = ['', ''].concat(extraArgs)
     const filePath = path.resolve(getYarnPath(version, rootPath), 'bin/yarn.js')
     const command = `${filePath} ${extraArgs.join(' ')}`
     log.info(command)
     try {
-        // WARNING :: When changing this logic ensure that passing of stdio works correctly. e.g. user input, arrows keys
-        // test:
-        // `nvm use 8.0.0` (lowest supported node version)
-        // `make install`
-        // `yvm exec contributors:add` and go through the steps
         execFileSync(filePath, extraArgs, {
             stdio: 'inherit',
         })
     } catch (error) {
-        log(error.message)
-        throw new Error('yarn failed, non-zero exit')
+        log('yarn failed, non-zero exit')
+        throw error
     }
 }
 
-export const exec = async (maybeVersion, rest) => {
+export const exec = async (maybeVersion, rest = []) => {
     try {
         const [version, args] = await getSplitVersionAndArgs(
             maybeVersion,

--- a/src/commands/exec.js
+++ b/src/commands/exec.js
@@ -37,9 +37,10 @@ export const exec = async (maybeVersion, rest) => {
         )
         await ensureVersionInstalled(version)
         await runYarn(version, args)
+        return 0
     } catch (e) {
         log(e.message)
         log.info(e.stack)
-        process.exit(1)
+        return 1
     }
 }

--- a/src/commands/getDefaultVersion.js
+++ b/src/commands/getDefaultVersion.js
@@ -1,0 +1,18 @@
+import log from '../util/log'
+import { getDefaultVersion as getDefault } from '../util/version'
+
+export const getDefaultVersion = async () => {
+    try {
+        const version = await getDefault()
+        if (version) {
+            log.capturable(version)
+            return 0
+        }
+        log('No default yarn version set')
+        return 1
+    } catch (e) {
+        log.error(e.message)
+        log.info(e.stack)
+        return 2
+    }
+}

--- a/src/commands/getNewPath.js
+++ b/src/commands/getNewPath.js
@@ -1,9 +1,12 @@
 import path from 'path'
 
+import log from '../util/log'
 import { versionRootPath } from '../util/utils'
 import { getCurrentPath, getPathDelimiter, yvmPath } from '../util/path'
+import { getSplitVersionAndArgs } from '../util/version'
+import { ensureVersionInstalled } from '../commands/install'
 
-export const getNewPath = ({
+export const buildNewPath = ({
     version,
     rootPath = yvmPath,
     shell,
@@ -31,4 +34,17 @@ export const getNewPath = ({
     }
 
     return splitPath.join(pathDelimiter).trim()
+}
+
+export const getNewPath = async (maybeVersion, shell) => {
+    try {
+        const [version] = await getSplitVersionAndArgs(maybeVersion)
+        await ensureVersionInstalled(version)
+        log.capturable(buildNewPath({ version, shell }))
+        return 0
+    } catch (e) {
+        log.error(e.message)
+        log.info(e.stack)
+        return 1
+    }
 }

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -4,7 +4,7 @@ import targz from 'targz'
 import * as openpgp from 'openpgp'
 
 import { YARN_PUBLIC_KEY_URL, YARN_RELEASE_TAGS_URL } from '../util/constants'
-import { LATEST } from '../util/alias'
+import { LATEST, STABLE } from '../util/alias'
 import { downloadFile } from '../util/download'
 import log from '../util/log'
 import { yvmPath } from '../util/path'
@@ -13,7 +13,7 @@ import {
     getExtractionPath,
     getVersionDownloadUrl,
 } from '../util/utils'
-import { resolveVersion } from '../util/version'
+import { getSplitVersionAndArgs, resolveVersion } from '../util/version'
 
 export const getDownloadPath = (version, rootPath) =>
     path.resolve(rootPath, 'versions', `yarn-v${version}.tar.gz`)
@@ -150,11 +150,25 @@ export const installVersion = async ({
     log('Installation successful')
 }
 
-export const installLatest = async ({ rootPath = yvmPath } = {}) => {
-    await installVersion({ rootPath, version: LATEST })
-}
-
 export const ensureVersionInstalled = async (version, rootPath = yvmPath) => {
     if (isVersionInstalled(version, rootPath)) return
     await installVersion({ version, rootPath })
+}
+
+export const install = async ({ latest, stable, version }) => {
+    try {
+        if (stable) {
+            version = STABLE
+        } else if (latest) {
+            version = LATEST
+        } else if (!version) {
+            version = (await getSplitVersionAndArgs())[0]
+        }
+        await installVersion({ version })
+        return 0
+    } catch (e) {
+        log(e.message)
+        log.info(e.stack)
+        return 1
+    }
 }

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -125,9 +125,8 @@ export const installVersion = async ({
     }
 
     if (isVersionInstalled(version, rootPath)) {
-        throw new Error(
-            `It looks like you already have yarn ${version} installed...`,
-        )
+        log(`It looks like you already have yarn ${version} installed...`)
+        return
     }
 
     log(`Installing yarn v${version} in ${rootPath}`)

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -20,3 +20,14 @@ export const listVersions = async rootPath => {
     }
     return installedVersions
 }
+
+export const list = async () => {
+    try {
+        log.info('Checking for installed yarn versions...')
+        await listVersions()
+        return 0
+    } catch (e) {
+        log(e.message)
+        return 2
+    }
+}

--- a/src/commands/listRemote.js
+++ b/src/commands/listRemote.js
@@ -7,7 +7,7 @@ import {
 } from '../util/version'
 
 export const listRemote = async () => {
-    log.info('list-remote')
+    log.info('Checking for available yarn versions...')
     try {
         const [remoteVersions, versionInUse, localVersions] = await Promise.all(
             [getVersionsFromTags(), getVersionInUse(), getYarnVersions()],

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -7,28 +7,27 @@ import { yvmPath } from '../util/path'
 import log from '../util/log'
 
 export const remove = async (versionString, rootPath = yvmPath) => {
-    const version = await resolveVersion({ versionString, yvmPath: rootPath })
-    const versionPath = getExtractionPath(version, rootPath)
-    const versionInUse = await getVersionInUse()
-
-    if (versionInUse && versionPath.includes(versionInUse)) {
-        log('You cannot remove currently-active version')
-        return 1
-    }
-
-    if (!fs.existsSync(versionPath)) {
-        log(
-            `Failed to remove yarn v${version}. Yarn version ${version} not found.`,
-        )
-        return 1
-    }
-
+    log.info(`Removing Yarn v${versionString}`)
     try {
+        const version = await resolveVersion({
+            versionString,
+            yvmPath: rootPath,
+        })
+        const versionPath = getExtractionPath(version, rootPath)
+        const versionInUse = await getVersionInUse()
+
+        if (versionInUse && versionPath.includes(versionInUse)) {
+            throw new Error('You cannot remove currently-active version')
+        }
+
+        if (!fs.existsSync(versionPath)) {
+            throw new Error(`Yarn version ${version} not found.`)
+        }
         fs.removeSync(versionPath)
         log(`Successfully removed yarn v${version}.`)
         return 0
     } catch (err) {
-        log(`Failed to remove yarn v${version}. \n ${err}`)
+        log(`Failed to remove yarn v${versionString}.\n${err.message}`)
         return 1
     }
 }

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -17,7 +17,7 @@ export const remove = async (versionString, rootPath = yvmPath) => {
         const versionInUse = await getVersionInUse()
 
         if (versionInUse && versionPath.includes(versionInUse)) {
-            throw new Error('You cannot remove currently-active version')
+            throw new Error('You cannot remove currently-active version.')
         }
 
         if (!fs.existsSync(versionPath)) {

--- a/src/commands/setDefault.js
+++ b/src/commands/setDefault.js
@@ -1,0 +1,15 @@
+import log from '../util/log'
+import { setDefaultVersion } from '../util/version'
+
+export const setDefault = async version => {
+    try {
+        if (!(await setDefaultVersion({ version }))) {
+            return 1
+        }
+        log('Default version set!')
+        return 0
+    } catch (e) {
+        log.error(e.message)
+        return 2
+    }
+}

--- a/src/commands/unalias.js
+++ b/src/commands/unalias.js
@@ -1,0 +1,16 @@
+import log from '../util/log'
+import { unsetAlias } from '../util/alias'
+
+export const unalias = async ({ name, force, recursive }) => {
+    try {
+        const deleted = await unsetAlias({ name, force, recursive })
+        if (!deleted) {
+            return 1
+        }
+        log('Alias successfully deleted')
+        return 0
+    } catch (e) {
+        log(e.message)
+        return 2
+    }
+}

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -147,9 +147,9 @@ export const getSplitVersionAndArgs = async (maybeVersionArg, ...rest) => {
                 log.info(`Using provided version: ${parsedVersionString}`)
                 return [parsedVersionString, rest]
             }
+            rest.unshift(maybeVersionArg)
         }
 
-        rest.unshift(maybeVersionArg)
         const rcVersion = getRcFileVersion()
         if (rcVersion) {
             log.info(`Resolving version '${rcVersion}' found in config`)

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -113,12 +113,8 @@ argParser
     .option('-R, --recursive', 'Delete all dependant aliases as well')
     .description('Deletes the alias named <name>')
     .action(async (name, { force, recursive }) => {
-        const { unsetAlias } = await import('./util/alias')
-        const deleted = await unsetAlias({ name, force, recursive })
-        if (deleted) {
-            log('Alias successfully deleted')
-        }
-        process.exit(deleted ? 0 : 1)
+        const { unalias } = await import('./commands/unalias')
+        process.exit(await unalias({ name, force, recursive }))
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -103,55 +103,8 @@ argParser.command(
 )
 argParser.command('alias', '', { noHelp: true }).action(async () => {
     const [, , , nameOrPattern, maybeVersion] = process.argv
-    const {
-        getFormatter,
-        resolveMatchingAliases,
-        setAlias,
-    } = await import('./util/alias')
-    const {
-        getVersionInUse,
-        getYarnVersions,
-        resolveVersion,
-    } = await import('./util/version')
-    const { getVersionsFromTags } = await import('./util/utils')
-
-    const format = getFormatter(
-        await getVersionsFromTags(),
-        getYarnVersions(),
-        await getVersionInUse(),
-    )
-
-    const safeResolveVersion = async versionString =>
-        resolveVersion({ versionString }).catch(e => log.info(e.message))
-
-    if (typeof maybeVersion === 'string') {
-        const name = nameOrPattern
-        const version = maybeVersion
-        let targetVersion
-        if (await setAlias({ name, version })) {
-            targetVersion = await safeResolveVersion(version)
-        }
-        const message = format(name, version, targetVersion)
-        if (targetVersion) {
-            log(message)
-            process.exit(0)
-        } else {
-            log.error(message)
-            process.exit(1)
-        }
-    } else {
-        const pattern = nameOrPattern || ''
-        const matchingAliases = await resolveMatchingAliases(pattern)
-        for (const {
-            name,
-            value: { value, version: versionString },
-        } of matchingAliases) {
-            const version = await safeResolveVersion(versionString)
-            log(format(name, value, version))
-        }
-        const noMatchFound = pattern.length > 0 && matchingAliases.length < 1
-        process.exit(noMatchFound ? 1 : 0)
-    }
+    const { alias } = await import('./commands/alias')
+    process.exit(await alias(nameOrPattern, maybeVersion))
 })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -168,14 +168,10 @@ argParser
     .command('get-default-version')
     .description(signPosting`alias default`)
     .action(async () => {
-        const { getDefaultVersion } = await import('./util/version')
-        const version = await getDefaultVersion()
-        if (version) {
-            log.capturable(version)
-        } else {
-            log('No default yarn version set')
-            process.exit(1)
-        }
+        const {
+            getDefaultVersion,
+        } = await import('./commands/getDefaultVersion')
+        process.exit(await getDefaultVersion())
     })
 
 argParser.parse(process.argv)

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -138,19 +138,8 @@ argParser
         'Internal command: Gets a new PATH string for "yvm use", installing the version if necessary',
     )
     .action(async (maybeVersion, { shell }) => {
-        const { getSplitVersionAndArgs } = await import('./util/version')
-        try {
-            const [version] = await getSplitVersionAndArgs(maybeVersion)
-            const { getNewPath } = await import('./commands/getNewPath')
-            const {
-                ensureVersionInstalled,
-            } = await import('./commands/install')
-            await ensureVersionInstalled(version)
-            log.capturable(getNewPath({ version, shell }))
-        } catch (error) {
-            log.error(error)
-            process.exit(1)
-        }
+        const { getNewPath } = await import('./commands/getNewPath')
+        process.exit(await getNewPath(maybeVersion, shell))
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -160,12 +160,8 @@ argParser
     .command('set-default <version>')
     .description(signPosting`alias default <version>`)
     .action(async version => {
-        const { setDefaultVersion } = await import('./util/version')
-        if (await setDefaultVersion({ version })) {
-            log('Default version set!')
-        } else {
-            process.exit(2)
-        }
+        const { setDefault } = await import('./commands/setDefault')
+        process.exit(await setDefault(version))
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -65,9 +65,10 @@ argParser
         messageOptionalVersion`Execute command using specified Yarn version`,
     )
     .action(async () => {
-        const [, , , maybeVersion, ...args] = process.argv
+        const [, , , maybeVersion, ...rest] = process.argv
         const { exec } = await import('./commands/exec')
-        await exec(maybeVersion, args)
+        const exitCode = await exec(maybeVersion, rest)
+        process.exit(exitCode)
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -42,14 +42,8 @@ argParser
     })
 
 const uninstallVersion = async version => {
-    log.info(`Removing Yarn v${version}`)
     const { remove } = await import('./commands/remove')
-    let exitCode = 1
-    try {
-        exitCode = await remove(version)
-    } catch (e) {
-        log(e.message)
-    }
+    const exitCode = await remove(version)
     process.exit(exitCode)
 }
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -43,8 +43,7 @@ argParser
 
 const uninstallVersion = async version => {
     const { remove } = await import('./commands/remove')
-    const exitCode = await remove(version)
-    process.exit(exitCode)
+    process.exit(await remove(version))
 }
 argParser
     .command('uninstall <version>')
@@ -67,8 +66,7 @@ argParser
     .action(async () => {
         const [, , , maybeVersion, ...rest] = process.argv
         const { exec } = await import('./commands/exec')
-        const exitCode = await exec(maybeVersion, rest)
-        process.exit(exitCode)
+        process.exit(await exec(maybeVersion, rest))
     })
 
 argParser
@@ -94,14 +92,8 @@ argParser
     .alias('ls-remote')
     .description('List Yarn versions available to install.')
     .action(async () => {
-        log.info('Checking for available yarn versions...')
         const { listRemote } = await import('./commands/listRemote')
-        try {
-            process.exit(await listRemote())
-        } catch (e) {
-            log(e.message)
-            process.exit(2)
-        }
+        process.exit(await listRemote())
     })
 
 argParser.command('alias [<pattern>]', 'Show all aliases matching <pattern>')

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -85,14 +85,8 @@ argParser
     .alias('ls')
     .description('List the currently installed versions of Yarn.')
     .action(async () => {
-        log.info('Checking for installed yarn versions...')
-        const { listVersions } = await import('./commands/list')
-        try {
-            await listVersions()
-        } catch (e) {
-            log(e.message)
-            process.exit(2)
-        }
+        const { list } = await import('./commands/list')
+        process.exit(await list())
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -32,24 +32,13 @@ argParser
     .option('-s, --stable', signPosting`install stable`)
     .description(messageOptionalVersion`Install the specified version of Yarn`)
     .action(async (maybeVersion, command) => {
-        const { LATEST, STABLE } = await import('./util/alias')
-        const { getSplitVersionAndArgs } = await import('./util/version')
-        const { installVersion } = await import('./commands/install')
-        try {
-            let version = maybeVersion
-            if (command.stable) {
-                version = STABLE
-            } else if (command.latest) {
-                version = LATEST
-            } else if (!version) {
-                version = (await getSplitVersionAndArgs())[0]
-            }
-            await installVersion({ version })
-        } catch (e) {
-            log(e.message)
-            log.info(e.stack)
-            process.exit(1)
-        }
+        const { install } = await import('./commands/install')
+        const exitCode = await install({
+            latest: command.latest,
+            stable: command.stable,
+            version: maybeVersion,
+        })
+        process.exit(exitCode)
     })
 
 const uninstallVersion = async version => {

--- a/test/commands/__snapshots__/alias.test.js.snap
+++ b/test/commands/__snapshots__/alias.test.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`alias getAlias handles no matches for supplied pattern 1`] = `Array []`;
+
+exports[`alias getAlias matches all aliases with empty pattern 1`] = `
+Array [
+  Array [
+    "[90m[32mdefault[90m → [37mstable[90m ([32m1.15.2[90m)[39m",
+  ],
+  Array [
+    "[90m[31mabc[90m → [37mb[90m ([31mN/A[90m)[39m",
+  ],
+  Array [
+    "[90m[31mbcd[90m → [37mz[90m ([31mN/A[90m)[39m",
+  ],
+  Array [
+    "[90m[33mxyz[90m → [37m1.13[90m ([33m1.13.0[90m)[39m",
+  ],
+  Array [
+    "[90m[32m[1mlatest[22m[90m → [32m[1m1.15.2[22m[90m[39m",
+  ],
+  Array [
+    "[90m[32m[1mstable[22m[90m → [32m[1m1.15.2[22m[90m[39m",
+  ],
+  Array [
+    "[90m[31m[1msystem[22m[90m → [31m[1mN/A[22m[90m[39m",
+  ],
+]
+`;
+
+exports[`alias getAlias matches only supplied pattern 1`] = `
+Array [
+  Array [
+    "[90m[31mabc[90m → [37mb[90m ([31mN/A[90m)[39m",
+  ],
+  Array [
+    "[90m[31mbcd[90m → [37mz[90m ([31mN/A[90m)[39m",
+  ],
+]
+`;
+
+exports[`alias setAlias handles invalid version 1`] = `
+Array [
+  Array [
+    "[31m[90m[31mdef[90m → [37minvalid[90m ([31mN/A[90m)[31m[39m",
+  ],
+]
+`;
+
+exports[`alias setAlias sets alias correctly 1`] = `
+Array [
+  Array [
+    "[90m[32mdef[90m → [37m1.15[90m ([32m1.15.2[90m)[39m",
+  ],
+]
+`;

--- a/test/commands/alias.test.js
+++ b/test/commands/alias.test.js
@@ -39,6 +39,7 @@ describe('alias', () => {
             allYarnVersions,
         )
         jest.spyOn(log, 'default')
+        jest.spyOn(log, 'error')
     })
 
     beforeEach(() => {
@@ -65,6 +66,13 @@ describe('alias', () => {
                 def: 'invalid',
             })
         })
+
+        it('handles thrown failure', async () => {
+            const mockError = new Error('some error')
+            utils.getVersionsFromTags.mockRejectedValueOnce(mockError)
+            expect(await alias('def', '1.15')).toBe(2)
+            expect(log.error).toHaveBeenCalledWith(mockError.message)
+        })
     })
 
     describe('getAlias', () => {
@@ -81,6 +89,13 @@ describe('alias', () => {
         it('handles no matches for supplied pattern', async () => {
             expect(await alias('abracadabra')).toBe(1)
             expect(log.default.mock.calls).toMatchSnapshot()
+        })
+
+        it('handles thrown failure', async () => {
+            const mockError = new Error('some error')
+            utils.getVersionsFromTags.mockRejectedValueOnce(mockError)
+            expect(await alias()).toBe(2)
+            expect(log.error).toHaveBeenCalledWith(mockError.message)
         })
     })
 })

--- a/test/commands/alias.test.js
+++ b/test/commands/alias.test.js
@@ -1,0 +1,86 @@
+import fs from 'fs-extra'
+import path from 'path'
+
+import { alias } from '../../src/commands/alias'
+import { STORAGE_FILE, getUserAliases } from '../../src/util/alias'
+import log from '../../src/util/log'
+import { yvmPath as rootPath } from '../../src/util/path'
+import * as utils from '../../src/util/utils'
+import * as version from '../../src/util/version'
+
+jest.mock('../../src/util/path', () => ({
+    yvmPath: '/tmp/yvmInstall',
+    getPathEntries: () => [],
+}))
+
+describe('alias', () => {
+    const currentYarnVersion = '1.15.2'
+    const installedYarnVersions = [currentYarnVersion, '1.13.0', '1.7.0']
+    const allYarnVersions = [...installedYarnVersions, '1.6.0', '1.3.0']
+    const mockAliases = {
+        abc: 'b',
+        bcd: 'z',
+        xyz: '1.13',
+    }
+
+    const writeAliases = () => {
+        const aliasFilePath = path.join(rootPath, STORAGE_FILE)
+        fs.writeFileSync(aliasFilePath, JSON.stringify(mockAliases))
+    }
+
+    beforeAll(() => {
+        jest.spyOn(version, 'getVersionInUse').mockResolvedValue(
+            currentYarnVersion,
+        )
+        jest.spyOn(version, 'getYarnVersions').mockReturnValue(
+            installedYarnVersions,
+        )
+        jest.spyOn(utils, 'getVersionsFromTags').mockResolvedValue(
+            allYarnVersions,
+        )
+        jest.spyOn(log, 'default')
+    })
+
+    beforeEach(() => {
+        writeAliases()
+        getUserAliases.cache.clear()
+        jest.clearAllMocks()
+    })
+
+    describe('setAlias', () => {
+        it('sets alias correctly', async () => {
+            expect(await alias('def', '1.15')).toBe(0)
+            expect(log.default.mock.calls).toMatchSnapshot()
+            expect(await getUserAliases()).toMatchObject({
+                ...mockAliases,
+                def: '1.15',
+            })
+        })
+
+        it('handles invalid version', async () => {
+            expect(await alias('def', 'invalid')).toBe(1)
+            expect(log.default.mock.calls).toMatchSnapshot()
+            expect(await getUserAliases()).toMatchObject({
+                ...mockAliases,
+                def: 'invalid',
+            })
+        })
+    })
+
+    describe('getAlias', () => {
+        it('matches all aliases with empty pattern', async () => {
+            expect(await alias()).toBe(0)
+            expect(log.default.mock.calls).toMatchSnapshot()
+        })
+
+        it('matches only supplied pattern', async () => {
+            expect(await alias('bc')).toBe(0)
+            expect(log.default.mock.calls).toMatchSnapshot()
+        })
+
+        it('handles no matches for supplied pattern', async () => {
+            expect(await alias('abracadabra')).toBe(1)
+            expect(log.default.mock.calls).toMatchSnapshot()
+        })
+    })
+})

--- a/test/commands/exec.test.js
+++ b/test/commands/exec.test.js
@@ -1,0 +1,62 @@
+import childProcess from 'child_process'
+import fs from 'fs-extra'
+// import path from 'path'
+jest.spyOn(childProcess, 'execFileSync')
+import * as install from '../../src/commands/install'
+jest.spyOn(install, 'ensureVersionInstalled')
+import { exec } from '../../src/commands/exec'
+// import { yvmPath as rootPath } from '../../src/util/path'
+import log from '../../src/util/log'
+
+jest.spyOn(log, 'default')
+jest.spyOn(log, 'info')
+jest.mock('../../src/util/path', () => ({
+    yvmPath: '/tmp/yvmInstall',
+    getPathEntries: () => [],
+}))
+
+describe('exec command', () => {
+    const rcVersion = '1.13.0'
+    beforeAll(() => {
+        fs.writeFileSync('.yvmrc', `${rcVersion}\n`)
+        childProcess.execFileSync.mockImplementation(() => {})
+        install.ensureVersionInstalled.mockImplementation(() => {})
+    })
+    afterEach(jest.clearAllMocks)
+
+    it('executes yarn with correct args', async () => {
+        const version = '1.7.0'
+        const args = ['extra', 'args']
+        expect(await exec(version, args)).toBe(0)
+        expect(install.ensureVersionInstalled).toHaveBeenCalledTimes(1)
+        expect(childProcess.execFileSync).toHaveBeenCalledWith(
+            `/tmp/yvmInstall/versions/v${version}/bin/yarn.js`,
+            args,
+            { stdio: 'inherit' },
+        )
+    })
+
+    it('executes yarn with correct rcVersion', async () => {
+        expect(await exec()).toBe(0)
+        expect(install.ensureVersionInstalled).toHaveBeenCalledTimes(1)
+        expect(childProcess.execFileSync).toHaveBeenCalledWith(
+            `/tmp/yvmInstall/versions/v${rcVersion}/bin/yarn.js`,
+            [],
+            { stdio: 'inherit' },
+        )
+    })
+
+    it('handles execution failure', async () => {
+        const mockError = new Error('yarn internal error')
+        childProcess.execFileSync.mockImplementationOnce(() => {
+            throw mockError
+        })
+        expect(await exec()).toBe(1)
+        expect(install.ensureVersionInstalled).toHaveBeenCalledTimes(1)
+        expect(log.default).toHaveBeenCalledWith(
+            expect.stringContaining('yarn failed'),
+        )
+        expect(log.default).toHaveBeenCalledWith(mockError.message)
+        expect(log.info).toHaveBeenCalledWith(mockError.stack)
+    })
+})

--- a/test/commands/getDefaultVersion.test.js
+++ b/test/commands/getDefaultVersion.test.js
@@ -1,0 +1,36 @@
+import log from '../../src/util/log'
+import * as version from '../../src/util/version'
+const getDefault = jest.spyOn(version, 'getDefaultVersion')
+import { getDefaultVersion } from '../../src/commands/getDefaultVersion'
+
+describe('unalias', () => {
+    jest.spyOn(log, 'capturable')
+    jest.spyOn(log, 'default')
+    jest.spyOn(log, 'error')
+    jest.spyOn(log, 'info')
+
+    beforeEach(jest.clearAllMocks)
+    afterAll(jest.restoreAllMocks)
+
+    it('handles deleted aliases', async () => {
+        getDefault.mockResolvedValueOnce('1.4.0')
+        expect(await getDefaultVersion()).toBe(0)
+        expect(log.capturable).toHaveBeenCalledWith('1.4.0')
+    })
+
+    it('handles no deleted aliases', async () => {
+        getDefault.mockResolvedValueOnce(null)
+        expect(await getDefaultVersion()).toBe(1)
+        expect(log.default).toHaveBeenCalledWith(
+            expect.stringContaining('No default yarn version'),
+        )
+    })
+
+    it('handles unset error', async () => {
+        const mockError = new Error('some message')
+        getDefault.mockRejectedValueOnce(mockError)
+        expect(await getDefaultVersion()).toBe(2)
+        expect(log.error).toHaveBeenCalledWith(mockError.message)
+        expect(log.info).toHaveBeenCalledWith(mockError.stack)
+    })
+})

--- a/test/commands/getDefaultVersion.test.js
+++ b/test/commands/getDefaultVersion.test.js
@@ -3,7 +3,7 @@ import * as version from '../../src/util/version'
 const getDefault = jest.spyOn(version, 'getDefaultVersion')
 import { getDefaultVersion } from '../../src/commands/getDefaultVersion'
 
-describe('unalias', () => {
+describe('getDefaultVersion', () => {
     jest.spyOn(log, 'capturable')
     jest.spyOn(log, 'default')
     jest.spyOn(log, 'error')

--- a/test/commands/getNewPath.test.js
+++ b/test/commands/getNewPath.test.js
@@ -1,8 +1,8 @@
 import path from 'path'
 
-import { getNewPath } from '../../src/commands/getNewPath'
+import { buildNewPath } from '../../src/commands/getNewPath'
 
-describe('getNewPath', () => {
+describe('buildNewPath', () => {
     it('Returns a new PATH string with a yarn directory prepended', () => {
         const mockVersion = '1.7.0'
         const mockRootPath = '/some/path'
@@ -14,7 +14,7 @@ describe('getNewPath', () => {
             ...mockSplitPath,
         ].join(path.delimiter)
         expect(
-            getNewPath({
+            buildNewPath({
                 version: mockVersion,
                 rootPath: mockRootPath,
                 pathString: mockPathString,
@@ -38,7 +38,7 @@ describe('getNewPath', () => {
             'def',
         ].join(path.delimiter)
         expect(
-            getNewPath({
+            buildNewPath({
                 version: mockVersion,
                 rootPath: mockRootPath,
                 pathString: mockPathString,
@@ -59,7 +59,7 @@ describe('getNewPath', () => {
                 ...mockSplitPath,
             ].join(FISH_ARRAY_DELIMITER)
             expect(
-                getNewPath({
+                buildNewPath({
                     shell: 'fish',
                     version: mockVersion,
                     rootPath: mockRootPath,
@@ -84,7 +84,7 @@ describe('getNewPath', () => {
                 'def',
             ].join(FISH_ARRAY_DELIMITER)
             expect(
-                getNewPath({
+                buildNewPath({
                     shell: 'fish',
                     version: mockVersion,
                     rootPath: mockRootPath,

--- a/test/commands/install.test.js
+++ b/test/commands/install.test.js
@@ -67,7 +67,7 @@ describe('yvm install', () => {
         const version = '1.7.0'
         expect(await install({ version })).toEqual(0)
         expect(fs.statSync(getExtractionPath(version, rootPath))).toBeTruthy()
-        expect(await install({ version })).toEqual(1)
+        expect(await install({ version })).toEqual(0)
         expect(log.default).toHaveBeenLastCalledWith(
             `It looks like you already have yarn ${version} installed...`,
         )

--- a/test/commands/install.test.js
+++ b/test/commands/install.test.js
@@ -1,9 +1,9 @@
 import fs from 'fs-extra'
 import targz from 'targz'
 
+import { LATEST } from '../../src/util/alias'
 import {
     ensureVersionInstalled,
-    installLatest,
     installVersion,
     getDownloadPath,
     getPublicKeyPath,
@@ -96,7 +96,7 @@ describe('yvm install', () => {
     it('Installs the lastest version of yarn', () => {
         return Promise.all([
             getVersionsFromTags(),
-            installLatest({ yvmPath: rootPath }),
+            installVersion({ version: LATEST, yvmPath: rootPath }),
         ]).then(results => {
             const remoteVersions = results[0]
             const latestVersion = remoteVersions[0]
@@ -109,7 +109,7 @@ describe('yvm install', () => {
     it('Uses default yvmPath on install latest', async () => {
         const [[latestVersion]] = await Promise.all([
             getVersionsFromTags(),
-            installLatest(),
+            installVersion({ version: LATEST }),
         ])
         expect(
             fs.statSync(getExtractionPath(latestVersion, rootPath)),

--- a/test/commands/install.test.js
+++ b/test/commands/install.test.js
@@ -184,7 +184,7 @@ describe('yvm install', () => {
         const expectedErrorMessage = 'Unable to locate extracted package'
         jest.spyOn(targz, 'decompress').mockImplementationOnce(
             ({ dest }, callback) => {
-                fs.mkdirSync(dest)
+                fs.emptyDirSync(dest)
                 callback()
             },
         )

--- a/test/commands/setDefault.test.js
+++ b/test/commands/setDefault.test.js
@@ -1,0 +1,40 @@
+import log from '../../src/util/log'
+import * as version from '../../src/util/version'
+const setDefaultVersion = jest.spyOn(version, 'setDefaultVersion')
+import { setDefault } from '../../src/commands/setDefault'
+
+describe('setDefault', () => {
+    jest.spyOn(log, 'capturable')
+    jest.spyOn(log, 'default')
+    jest.spyOn(log, 'error')
+
+    beforeEach(jest.clearAllMocks)
+    afterAll(jest.restoreAllMocks)
+
+    it('handles set default successful', async () => {
+        const version = '1.4.0'
+        setDefaultVersion.mockResolvedValueOnce(true)
+        expect(await setDefault(version)).toBe(0)
+        expect(setDefaultVersion).toHaveBeenCalledWith({ version })
+        expect(log.default).toHaveBeenCalledWith(
+            expect.stringContaining('Default version set'),
+        )
+    })
+
+    it('handles set default unsuccessful', async () => {
+        const version = '1.4.0'
+        setDefaultVersion.mockResolvedValueOnce(false)
+        expect(await setDefault(version)).toBe(1)
+        expect(setDefaultVersion).toHaveBeenCalledWith({ version })
+        expect(log.default).not.toHaveBeenCalled()
+    })
+
+    it('handles unset error', async () => {
+        const mockError = new Error('some message')
+        setDefaultVersion.mockRejectedValueOnce(mockError)
+        const version = '1.4.0'
+        expect(await setDefault(version)).toBe(2)
+        expect(setDefaultVersion).toHaveBeenCalledWith({ version })
+        expect(log.error).toHaveBeenCalledWith(mockError.message)
+    })
+})

--- a/test/commands/unalias.test.js
+++ b/test/commands/unalias.test.js
@@ -1,0 +1,37 @@
+import * as alias from '../../src/util/alias'
+import log from '../../src/util/log'
+import { unalias } from '../../src/commands/unalias'
+
+describe('unalias', () => {
+    jest.spyOn(log, 'default')
+    const unsetAlias = jest.spyOn(alias, 'unsetAlias')
+
+    beforeEach(jest.clearAllMocks)
+    afterAll(jest.restoreAllMocks)
+
+    it('handles deleted aliases', async () => {
+        unsetAlias.mockResolvedValueOnce(true)
+        const args = { name: 'mock-name', force: false, recursive: true }
+        expect(await unalias(args)).toBe(0)
+        expect(unsetAlias).toHaveBeenCalledWith(args)
+        expect(log.default).toHaveBeenCalledWith(
+            expect.stringContaining('successfully deleted'),
+        )
+    })
+
+    it('handles no deleted aliases', async () => {
+        unsetAlias.mockResolvedValueOnce(false)
+        const args = { name: 'mock-name', force: true, recursive: false }
+        expect(await unalias(args)).toBe(1)
+        expect(unsetAlias).toHaveBeenCalledWith(args)
+        expect(log.default).not.toHaveBeenCalled()
+    })
+
+    it('handles unset error', async () => {
+        unsetAlias.mockRejectedValueOnce(new Error('some message'))
+        const args = { name: 'mock-name' }
+        expect(await unalias(args)).toBe(2)
+        expect(unsetAlias).toHaveBeenCalledWith(args)
+        expect(log.default).toHaveBeenCalledWith('some message')
+    })
+})


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Moves all logic to the commands and only returns exit codes to the `yvm.js` file

### Checklist
- [ ] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Please `make install`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- `yvm help`
  - Attempt all commands

### Comments
<!-- Any other comments you want to include for reviewers. -->
