### PR TITLE
fix: fish user paths

### DIFF
--- a/src/util/path.js
+++ b/src/util/path.js
@@ -12,7 +12,7 @@ export const getPathDelimiter = shell => {
 
 export const getCurrentPath = shell => {
     if (isFishShell(shell)) {
-        return process.env.FISH_USER_PATHS || ''
+        return process.env.fish_user_paths || ''
     }
     return process.env.PATH || ''
 }

--- a/test/commands/current.test.js
+++ b/test/commands/current.test.js
@@ -37,7 +37,7 @@ describe('yvm current command', () => {
         )
     })
     it('fails if fish environment path is not available', async () => {
-        delete process.env.FISH_USER_PATHS
+        delete process.env.fish_user_paths
         expect(await current({ shell: 'fish' })).toBe(1)
         expect(log).toHaveBeenCalledWith(
             expect.stringContaining(`PATH not found`),

--- a/test/util/alias.test.js
+++ b/test/util/alias.test.js
@@ -72,8 +72,8 @@ describe('alias', () => {
 
         it('gets first non yvm yarn executable in fish shell', async () => {
             const yvmPath = '/Users/tophat/.yvm'
-            const oldPath = process.env.FISH_USER_PATHS
-            process.env.FISH_USER_PATHS = `${yvmPath}/versions/v1.13.0/bin /usr/local/bin:`
+            const oldPath = process.env.fish_user_paths
+            process.env.fish_user_paths = `${yvmPath}/versions/v1.13.0/bin /usr/local/bin:`
             childProcess.execSync.mockReturnValueOnce('1.14.0')
             expect(
                 await alias.resolveSystem({ shell: 'fish', yvmPath }),
@@ -81,17 +81,17 @@ describe('alias', () => {
             expect(childProcess.execSync).toHaveBeenCalledWith(
                 expect.stringContaining('usr/local/bin/yarn'),
             )
-            process.env.FISH_USER_PATHS = oldPath
+            process.env.fish_user_paths = oldPath
         })
 
         it('returns nothing if yarn not found in fish user path', async () => {
-            const oldPath = process.env.FISH_USER_PATHS
-            process.env.FISH_USER_PATHS =
+            const oldPath = process.env.fish_user_paths
+            process.env.fish_user_paths =
                 '/Users/tophat/.nvm/versions/node/v6.11.5/bin '
             expect(
                 await alias.resolveSystem({ shell: 'fish', yvmPath }),
             ).toEqual(alias.NOT_AVAILABLE)
-            process.env.FISH_USER_PATHS = oldPath
+            process.env.fish_user_paths = oldPath
         })
     })
 


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Replaces `FISH_USER_PATHS` with `fish_user_paths` environment variable for the fish shell, [see docs](https://fishshell.com/docs/current/)

### Checklist
- [ ] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- In your fish config file before the source `yvm.fish` line
```fish
set -U fish_user_paths "/usr/local/bin" $fish_user_paths
```
- Reload fish shell
- `echo $fish_user_paths` will only have the yvm yarn path
- `make install`
- Reload fish shell
- `echo $fish_user_paths` will only have all paths set previously and the yvm yarn path

### Comments
<!-- Any other comments you want to include for reviewers. -->
- Fixes #353 