### PR TITLE
fix: use yarn latest version link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 * unload yvm from PATH command
 * unload yvm from shell command
+* use yarn self update version url for stable version
 
 ## [v3.2.0](https://github.com/tophat/yvm/compare/v3.0.1...v3.0.2) (2019-04-12)
 

--- a/src/util/alias.js
+++ b/src/util/alias.js
@@ -7,7 +7,7 @@ import memoize from 'lodash.memoize'
 import log from './log'
 import { getRequest, getVersionsFromTags } from './utils'
 import { getPathEntries, yvmPath as defaultYvmPath } from './path'
-import { YARN_INSTALL_PAGE_URL, YARN_INSTALL_STABLE_REGEX } from './constants'
+import { YARN_STABLE_VERSION_URL } from './constants'
 
 export const STORAGE_FILE = '.aliases'
 
@@ -26,9 +26,8 @@ export const resolveLatest = memoize(
 )
 
 export const resolveStable = memoize(async () => {
-    const body = await getRequest(YARN_INSTALL_PAGE_URL)
-    const matches = body.match(YARN_INSTALL_STABLE_REGEX)
-    return matches ? matches[1] : UNRESOLVED
+    const version = await getRequest(YARN_STABLE_VERSION_URL)
+    return version || UNRESOLVED
 })
 
 export const resolveSystem = memoize(

--- a/src/util/alias.js
+++ b/src/util/alias.js
@@ -27,7 +27,7 @@ export const resolveLatest = memoize(
 
 export const resolveStable = memoize(async () => {
     const version = await getRequest(YARN_STABLE_VERSION_URL)
-    return version || UNRESOLVED
+    return (version && version.trim()) || UNRESOLVED
 })
 
 export const resolveSystem = memoize(

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -1,10 +1,9 @@
 export const USER_AGENT = 'YVM'
 
 export const YARN_DOWNLOAD_URL = 'https://yarnpkg.com/downloads'
-export const YARN_INSTALL_PAGE_URL = 'https://yarnpkg.com/lang/en/docs/install/'
-export const YARN_INSTALL_STABLE_REGEX = /stable \(([\w.-]+)\)/i
+export const YARN_PUBLIC_KEY_URL = 'https://dl.yarnpkg.com/debian/pubkey.gpg'
 export const YARN_RELEASE_TAGS_URL =
     'https://github.com/yarnpkg/yarn/releases/tag'
 export const YARN_RELEASES_API_URL =
     'https://d236jo9e8rrdox.cloudfront.net/yarn-releases'
-export const YARN_PUBLIC_KEY_URL = 'https://dl.yarnpkg.com/debian/pubkey.gpg'
+export const YARN_STABLE_VERSION_URL = 'https://yarnpkg.com/latest-version'

--- a/test/util/alias.test.js
+++ b/test/util/alias.test.js
@@ -29,16 +29,15 @@ describe('alias', () => {
         })
 
         it('gets stable version', async () => {
-            utils.getRequest.mockReturnValueOnce(
-                '<html><body><span>Stable (1.15.2)</span></body></html>',
-            )
+            utils.getRequest.mockReturnValueOnce(' 1.15.2 ')
             expect(await alias.resolveStable()).toBe('1.15.2')
+            expect(utils.getRequest).toHaveBeenCalledWith(
+                'https://yarnpkg.com/latest-version',
+            )
         })
 
         it('does not get stable version', async () => {
-            utils.getRequest.mockReturnValueOnce(
-                '<html><body><span></span></body></html>',
-            )
+            utils.getRequest.mockReturnValueOnce('  ')
             expect(await alias.resolveStable()).toBe(alias.UNRESOLVED)
         })
     })


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
Switch to using the same link [yarn has internally](https://github.com/yarnpkg/yarn/search?q=SELF_UPDATE_VERSION_URL&unscoped_q=SELF_UPDATE_VERSION_URL) to determine new versions.

### Checklist
- [x] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Please `make install`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- `yvm alias stable`
- `yvm i stable`
- `yvm ls`
- `yvm use stable`
- `yvm rm stable`

### Comments
<!-- Any other comments you want to include for reviewers. -->
