### PR TITLE
fix: replace fish universal variable with global export

### DIFF
--- a/.github/tap-release.yml
+++ b/.github/tap-release.yml
@@ -22,7 +22,7 @@ template: >
         s.gsub! "curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.js | YVM_INSTALL_DIR=${YVM_DIR} node", update_self_disabled
       end
       inreplace "yvm.fish" do |s|
-        s.gsub! 'set -q YVM_DIR; or set -U YVM_DIR "$HOME/.yvm"', "set -U YVM_DIR '#{prefix}'"
+        s.gsub! 'set -q YVM_DIR; or set -gx YVM_DIR "$HOME/.yvm"', "set -gx YVM_DIR '#{prefix}'"
         s.gsub! "env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.js | node", update_self_disabled
       end
       chmod 0755, "yvm.sh"

--- a/src/yvm.fish
+++ b/src/yvm.fish
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -q YVM_DIR; or set -U YVM_DIR "$HOME/.yvm"
+set -q YVM_DIR; or set -gx YVM_DIR "$HOME/.yvm"
 
 function yvm
     set command $argv[1]
@@ -15,7 +15,7 @@ function yvm
         if [ -z "$NEW_FISH_USER_PATHS" ]
             yvm_err "Could not get new path from yvm"
         else
-            set -U fish_user_paths (string split ' ' -- $NEW_FISH_USER_PATHS)
+            set -gx fish_user_paths (string split ' ' -- $NEW_FISH_USER_PATHS)
             set -l new_version (yarn --version)
             yvm_echo "Now using yarn version $new_version"
         end
@@ -40,7 +40,7 @@ function yvm
             yvm_err "%s\n" "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your fish config file"
             exit 1
         end
-        set -U fish_user_paths "$YVM_DIR/shim" $fish_user_paths
+        set -gx fish_user_paths "$YVM_DIR/shim" $fish_user_paths
     end
 
     if [ "$command" = "use" ]


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
There's no need to set yvm variables at universal level. Set at global scope and export to allow child processes access.

### Checklist
- [ ] This PR has updated documentation
- [ ] This PR has sufficient testing

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Install fish shell
- Please `make install`, this PR uses a new package

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- Launch fish shell
- `which yarn` should point to shimmed yarn
- `yarn --version`
- `yvm use <version>`
- `which yarn` should point to yvm managed yarn version
- `yarn --version`

### Comments
<!-- Any other comments you want to include for reviewers. -->
