### PR TITLE
Current command incompatible with yarn shim

### DIFF
--- a/src/commands/current.js
+++ b/src/commands/current.js
@@ -1,50 +1,29 @@
-import path from 'path'
-
-import {
-    getRcFileVersion,
-    getValidVersionString,
-    getVersionInUse,
-} from 'util/version'
+import { getRcFileVersion, getVersionInUse } from 'util/version'
 import log from 'util/log'
-import { versionRootPath } from 'util/utils'
-import { getCurrentPath, getPathDelimiter, yvmPath } from 'util/path'
+import { getYarnPathEntries, isYvmPath } from 'util/path'
 
-export const current = async ({ path: pathToUse, shell } = {}) => {
-    const pathDelimiter = getPathDelimiter(shell)
+export const current = async ({ shell } = {}) => {
     const versionInUse = await getVersionInUse()
     if (!versionInUse) {
         log('Sorry, yarn is NOT installed.')
         return 1
     }
-    const envPath = pathToUse || getCurrentPath(shell)
-    if (!envPath) {
-        log('Environment PATH not found.')
-        return 1
+    const [maybeYvmYarn] = getYarnPathEntries(shell)
+    log.info(`yarn exec: ${maybeYvmYarn}`)
+    if (!isYvmPath(maybeYvmYarn)) {
+        log('Yarn was NOT installed by yvm')
+        return 2
     }
-    for (const element of envPath.split(pathDelimiter)) {
-        if (element.startsWith(versionRootPath(yvmPath))) {
-            const [pathVersion] = element
-                .split(path.sep)
-                .map(getValidVersionString)
-                .filter(a => a)
-            log.info(`matched yvm version: v${pathVersion} in PATH ${element}`)
-
-            const rcVersion = getRcFileVersion()
-            log(`Currently on yarn version ${pathVersion}`)
-            if (rcVersion !== null) {
-                if (pathVersion === rcVersion) {
-                    log(
-                        'Your .yvmrc version matches your PATH version, good job!',
-                    )
-                } else {
-                    log(
-                        `Your .yvmrc version: ${rcVersion} and PATH version: ${pathVersion} don't match :(`,
-                    )
-                }
-            }
-            return 0
+    log(`Currently on yarn version ${versionInUse}`)
+    const rcVersion = getRcFileVersion()
+    if (rcVersion !== null) {
+        if (versionInUse === rcVersion) {
+            log('Your .yvmrc version matches your PATH version, good job!')
+        } else {
+            log(
+                `Your .yvmrc version: ${rcVersion} and PATH version: ${versionInUse} don't match :(`,
+            )
         }
     }
-    log('Yarn was NOT installed by yvm')
-    return 2
+    return 0
 }

--- a/src/util/alias.js
+++ b/src/util/alias.js
@@ -5,7 +5,7 @@ import chalk from 'chalk'
 import memoize from 'lodash.memoize'
 
 import log from 'util/log'
-import { getPathEntries, yvmPath as defaultYvmPath } from 'util/path'
+import { getNonYvmYarnPathEntries, yvmPath as defaultYvmPath } from 'util/path'
 import { getRequest, getVersionsFromTags } from 'util/utils'
 import { YARN_STABLE_VERSION_URL } from 'util/constants'
 
@@ -32,7 +32,7 @@ export const resolveStable = memoize(async () => {
 
 export const resolveSystem = memoize(
     async ({ shell, yvmPath = defaultYvmPath } = {}) => {
-        for (const pathEntry of getPathEntries(shell)) {
+        for (const pathEntry of getNonYvmYarnPathEntries(shell)) {
             if (
                 pathEntry === '' ||
                 pathEntry === '.' ||

--- a/src/util/alias.js
+++ b/src/util/alias.js
@@ -30,27 +30,17 @@ export const resolveStable = memoize(async () => {
     return (version && version.trim()) || UNRESOLVED
 })
 
-export const resolveSystem = memoize(
-    async ({ shell, yvmPath = defaultYvmPath } = {}) => {
-        for (const pathEntry of getNonYvmYarnPathEntries(shell)) {
-            if (
-                pathEntry === '' ||
-                pathEntry === '.' ||
-                pathEntry.includes(yvmPath)
-            ) {
-                continue
-            }
-            try {
-                const pathToExec = path.join(pathEntry, 'yarn')
-                const execCommand = `${pathToExec} --version 2> /dev/null`
-                return String(execSync(execCommand)).trim()
-            } catch (error) {
-                log.info(error.message)
-            }
+export const resolveSystem = memoize(async ({ shell } = {}) => {
+    for (const pathToExec of getNonYvmYarnPathEntries(shell)) {
+        try {
+            const execCommand = `${pathToExec} --version 2> /dev/null`
+            return String(execSync(execCommand)).trim()
+        } catch (error) {
+            log.info(error.message)
         }
-        return NOT_AVAILABLE
-    },
-)
+    }
+    return NOT_AVAILABLE
+})
 
 export const isReserved = name => RESERVED_NAMES.includes(name)
 

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -1,5 +1,6 @@
 import os from 'os'
 import path from 'path'
+import fs from 'fs'
 
 const isFishShell = shell => shell === 'fish'
 
@@ -17,8 +18,15 @@ export const getCurrentPath = shell => {
     return process.env.PATH || ''
 }
 
-export const getPathEntries = shell => {
-    return getCurrentPath(shell).split(getPathDelimiter(shell))
-}
+export const getPathEntries = shell =>
+    getCurrentPath(shell).split(getPathDelimiter(shell))
+
+export const getYarnPathEntries = shell =>
+    getPathEntries(shell).filter(p => fs.existsSync(path.join(p, 'yarn')))
 
 export const yvmPath = process.env.YVM_DIR || path.resolve(os.homedir(), '.yvm')
+
+export const isYvmPath = p => p.startsWith(yvmPath)
+
+export const getNonYvmYarnPathEntries = shell =>
+    getYarnPathEntries(shell).filter(p => !isYvmPath(p))

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -22,11 +22,13 @@ export const getPathEntries = shell =>
     getCurrentPath(shell).split(getPathDelimiter(shell))
 
 export const getYarnPathEntries = shell =>
-    getPathEntries(shell).filter(p => fs.existsSync(path.join(p, 'yarn')))
+    getPathEntries(shell)
+        .map(p => path.join(p, 'yarn'))
+        .filter(fs.existsSync)
 
 export const yvmPath = process.env.YVM_DIR || path.resolve(os.homedir(), '.yvm')
 
-export const isYvmPath = p => p.startsWith(yvmPath)
+export const isYvmPath = p => p && p.startsWith(yvmPath)
 
 export const getNonYvmYarnPathEntries = shell =>
     getYarnPathEntries(shell).filter(p => !isYvmPath(p))

--- a/test/commands/__snapshots__/alias.test.js.snap
+++ b/test/commands/__snapshots__/alias.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`alias getAlias handles no matches for supplied pattern 1`] = `Array []`;
+exports[`alias command getAlias handles no matches for supplied pattern 1`] = `Array []`;
 
-exports[`alias getAlias matches all aliases with empty pattern 1`] = `
+exports[`alias command getAlias matches all aliases with empty pattern 1`] = `
 Array [
   Array [
     "[90m[32mdefault[90m → [37mstable[90m ([32m1.15.2[90m)[39m",
@@ -28,7 +28,7 @@ Array [
 ]
 `;
 
-exports[`alias getAlias matches only supplied pattern 1`] = `
+exports[`alias command getAlias matches only supplied pattern 1`] = `
 Array [
   Array [
     "[90m[31mabc[90m → [37mb[90m ([31mN/A[90m)[39m",
@@ -39,7 +39,7 @@ Array [
 ]
 `;
 
-exports[`alias setAlias handles invalid version 1`] = `
+exports[`alias command setAlias handles invalid version 1`] = `
 Array [
   Array [
     "[31m[90m[31mdef[90m → [37minvalid[90m ([31mN/A[90m)[31m[39m",
@@ -47,7 +47,7 @@ Array [
 ]
 `;
 
-exports[`alias setAlias sets alias correctly 1`] = `
+exports[`alias command setAlias sets alias correctly 1`] = `
 Array [
   Array [
     "[90m[32mdef[90m → [37m1.15[90m ([32m1.15.2[90m)[39m",

--- a/test/commands/alias.test.js
+++ b/test/commands/alias.test.js
@@ -13,7 +13,7 @@ jest.mock('util/path', () => ({
     getNonYvmYarnPathEntries: () => [],
 }))
 
-describe('alias', () => {
+describe('alias command', () => {
     const { resolveVersion } = version
     const currentYarnVersion = '1.15.2'
     const pinnedStableVersion = currentYarnVersion

--- a/test/commands/alias.test.js
+++ b/test/commands/alias.test.js
@@ -10,7 +10,7 @@ import * as version from 'util/version'
 
 jest.mock('util/path', () => ({
     yvmPath: '/tmp/cmd/alias/yvm',
-    getPathEntries: () => [],
+    getNonYvmYarnPathEntries: () => [],
 }))
 
 describe('alias', () => {

--- a/test/commands/current.test.js
+++ b/test/commands/current.test.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import * as path from 'util/path'
-path.yvmPath = '/Users/tophat/.yvm'
+const getYarnPathEntries = jest.spyOn(path, 'getYarnPathEntries')
+const isYvmPath = jest.spyOn(path, 'isYvmPath')
 import * as version from 'util/version'
 const getVersionInUse = jest
     .spyOn(version, 'getVersionInUse')
@@ -8,59 +9,51 @@ const getVersionInUse = jest
 import { current } from 'commands/current'
 import log from 'util/log'
 
-jest.mock('util/log')
-
 describe('yvm current command', () => {
-    let processEnv
-    beforeEach(() => {
-        processEnv = Object.assign({}, process.env)
-    })
-    afterEach(() => {
-        process.env = Object.assign({}, processEnv)
-    })
+    const mockYvmPath = '/User/tophat/.yvm'
+    jest.spyOn(log, 'default')
+
     afterAll(() => {
         jest.restoreAllMocks()
     })
+
     it('fails if yarn not installed and active', async () => {
         getVersionInUse.mockResolvedValueOnce('')
-        const path = '/Users/tophat/.nvm/versions/node/v6.11.5/bin:'
-        expect(await current({ path })).toBe(1)
-        expect(log).toHaveBeenCalledWith(
+        expect(await current()).toBe(1)
+        expect(log.default).toHaveBeenCalledWith(
             expect.stringContaining(`yarn is NOT installed`),
         )
     })
-    it('fails if environment path is not available', async () => {
-        delete process.env.PATH
-        expect(await current()).toBe(1)
-        expect(log).toHaveBeenCalledWith(
-            expect.stringContaining(`PATH not found`),
-        )
-    })
-    it('fails if fish environment path is not available', async () => {
-        delete process.env.fish_user_paths
-        expect(await current({ shell: 'fish' })).toBe(1)
-        expect(log).toHaveBeenCalledWith(
-            expect.stringContaining(`PATH not found`),
-        )
-    })
+
     it('fails to find yarn version if yvm not installed', async () => {
-        const path = '/Users/tophat/.nvm/versions/node/v6.11.5/bin:'
-        expect(await current({ path })).toBe(2)
-        expect(log).toHaveBeenCalledWith(
+        getYarnPathEntries.mockReturnValueOnce(['/usr/local/bin/yarn'])
+        expect(await current()).toBe(2)
+        expect(log.default).toHaveBeenCalledWith(
             expect.stringContaining(`Yarn was NOT installed by yvm`),
         )
     })
+
     it('Succeeds if yvm version matches .yvmrc', async () => {
-        const version = fs.readFileSync('.yvmrc', 'utf8')
-        const path = `/Users/tophat/.yvm/versions/v${version}/bin:`
-        expect(await current({ path })).toBe(0)
-        expect(log).toHaveBeenCalledWith(
+        const version = fs.readFileSync('.yvmrc', 'utf8').trim()
+        isYvmPath.mockReturnValueOnce(true)
+        getVersionInUse.mockResolvedValueOnce(version)
+        getYarnPathEntries.mockReturnValueOnce([
+            `${mockYvmPath}/versions/v${version}/bin`,
+        ])
+        expect(await current()).toBe(0)
+        expect(log.default).toHaveBeenCalledWith(
             expect.stringContaining(`version matches your PATH version`),
         )
     })
+
     it('Succeeds if yvm version does not match .yvmrc', async () => {
-        const path = '/Users/tophat/.yvm/versions/v0.0.0/bin:'
-        expect(await current({ path })).toBe(0)
-        expect(log).toHaveBeenCalledWith(expect.stringContaining(`don't match`))
+        isYvmPath.mockReturnValueOnce(true)
+        getYarnPathEntries.mockReturnValueOnce([
+            `${mockYvmPath}/versions/v0.0.0/bin`,
+        ])
+        expect(await current()).toBe(0)
+        expect(log.default).toHaveBeenCalledWith(
+            expect.stringContaining(`don't match`),
+        )
     })
 })

--- a/test/util/__snapshots__/alias.test.js.snap
+++ b/test/util/__snapshots__/alias.test.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`alias getFormatter formats and colors inputs correctly available alias 1`] = `"[90m[37mavailable[90m → [37m1.5[90m ([37m1.5.0[90m)[39m"`;
+exports[`alias util getFormatter formats and colors inputs correctly available alias 1`] = `"[90m[37mavailable[90m → [37m1.5[90m ([37m1.5.0[90m)[39m"`;
 
-exports[`alias getFormatter formats and colors inputs correctly current alias 1`] = `"[90m[32mcurrent[90m → [37m^1.1[90m ([32m1.13.0[90m)[39m"`;
+exports[`alias util getFormatter formats and colors inputs correctly current alias 1`] = `"[90m[32mcurrent[90m → [37m^1.1[90m ([32m1.13.0[90m)[39m"`;
 
-exports[`alias getFormatter formats and colors inputs correctly installed alias 1`] = `"[90m[33minstalled[90m → [37m1.3[90m ([33m1.3.0[90m)[39m"`;
+exports[`alias util getFormatter formats and colors inputs correctly installed alias 1`] = `"[90m[33minstalled[90m → [37m1.3[90m ([33m1.3.0[90m)[39m"`;
 
-exports[`alias getFormatter formats and colors inputs correctly stable alias 1`] = `"[90m[32m[1mstable[22m[90m → [32m[1m1.13.0[22m[90m[39m"`;
+exports[`alias util getFormatter formats and colors inputs correctly stable alias 1`] = `"[90m[32m[1mstable[22m[90m → [32m[1m1.13.0[22m[90m[39m"`;
 
-exports[`alias getFormatter formats and colors inputs correctly system alias 1`] = `"[90m[31m[1msystem[22m[90m → [31m[1mN/A[22m[90m[39m"`;
+exports[`alias util getFormatter formats and colors inputs correctly system alias 1`] = `"[90m[31m[1msystem[22m[90m → [31m[1mN/A[22m[90m[39m"`;
 
-exports[`alias getFormatter formats and colors inputs correctly unavailable alias 1`] = `"[90m[31munavailable[90m → [37m1.1[90m ([31mN/A[90m)[39m"`;
+exports[`alias util getFormatter formats and colors inputs correctly unavailable alias 1`] = `"[90m[31munavailable[90m → [37m1.1[90m ([31mN/A[90m)[39m"`;
 
-exports[`alias getFormatter formats and colors inputs correctly undefined alias 1`] = `"[90m[31mundefined[90m → [37m1.2.0[90m ([31mN/A[90m)[39m"`;
+exports[`alias util getFormatter formats and colors inputs correctly undefined alias 1`] = `"[90m[31mundefined[90m → [37m1.2.0[90m ([31mN/A[90m)[39m"`;
 
-exports[`alias resolveAliases does not crash on cyclic alias dependancy 1`] = `
+exports[`alias util resolveAliases does not crash on cyclic alias dependancy 1`] = `
 Array [
   Object {
     "name": "default",
@@ -68,7 +68,7 @@ Array [
 ]
 `;
 
-exports[`alias resolveAliases matches all aliases on empty pattern 1`] = `
+exports[`alias util resolveAliases matches all aliases on empty pattern 1`] = `
 Array [
   Object {
     "name": "default",

--- a/test/util/alias.test.js
+++ b/test/util/alias.test.js
@@ -58,7 +58,8 @@ describe('alias util', () => {
 
         afterEach(() => {
             alias.resolveSystem.cache.clear()
-            jest.resetAllMocks()
+            pathSpy.mockReset()
+            fishUserPathSpy.mockReset()
         })
 
         afterAll(() => {
@@ -81,7 +82,7 @@ describe('alias util', () => {
 
         it('gets first non yvm yarn executable in fish shell', async () => {
             fishUserPathSpy.mockValue(
-                `${yvmPath}/versions/v1.13.0/bin /usr/local/bin:`,
+                `${yvmPath}/versions/v1.13.0/bin /usr/local/bin`,
             )
             childProcess.execSync.mockReturnValueOnce('1.14.0')
             expect(await alias.resolveSystem({ shell: 'fish' })).toEqual(
@@ -93,13 +94,12 @@ describe('alias util', () => {
         })
 
         it('returns nothing if yarn not found in fish user path', async () => {
-            const oldPath = process.env.fish_user_paths
-            process.env.fish_user_paths =
-                '/Users/tophat/.nvm/versions/node/v6.11.5/bin '
+            fishUserPathSpy.mockValue(
+                '/Users/tophat/.nvm/versions/node/v6.11.5/bin ',
+            )
             expect(await alias.resolveSystem({ shell: 'fish' })).toEqual(
                 alias.NOT_AVAILABLE,
             )
-            process.env.fish_user_paths = oldPath
         })
     })
 
@@ -206,7 +206,7 @@ describe('alias util', () => {
                 await alias.setAlias({
                     name: 'test',
                     version: '1.7.0',
-                    yvmPath: yvmPath,
+                    yvmPath,
                 }),
             ).toBe(true)
             expect(await alias.getUserAliases(yvmPath)).toEqual({
@@ -222,7 +222,7 @@ describe('alias util', () => {
                     await alias.setAlias({
                         name: alias.STABLE,
                         version: '1.7.0',
-                        yvmPath: yvmPath,
+                        yvmPath,
                     }),
                 ).toBe(false)
                 expect(log.default).toHaveBeenCalledWith(
@@ -257,7 +257,7 @@ describe('alias util', () => {
             expect(
                 await alias.unsetAlias({
                     name: alias.STABLE,
-                    yvmPath: yvmPath,
+                    yvmPath,
                 }),
             ).toBe(false)
             expect(log.default).toHaveBeenCalledWith(
@@ -277,7 +277,7 @@ describe('alias util', () => {
             expect(
                 await alias.unsetAlias({
                     name: 'zero',
-                    yvmPath: yvmPath,
+                    yvmPath,
                 }),
             ).toBe(false)
             expect(fs.writeFileSync).not.toHaveBeenCalled()
@@ -301,7 +301,7 @@ describe('alias util', () => {
                 await alias.unsetAlias({
                     name: 'zero',
                     force: true,
-                    yvmPath: yvmPath,
+                    yvmPath,
                 }),
             ).toBe(true)
             delete mockAliases.zero
@@ -324,7 +324,7 @@ describe('alias util', () => {
                 await alias.unsetAlias({
                     name: 'zero',
                     recursive: true,
-                    yvmPath: yvmPath,
+                    yvmPath,
                 }),
             ).toBe(true)
             expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -345,7 +345,7 @@ describe('alias util', () => {
                 await alias.unsetAlias({
                     name: 'zero',
                     recursive: true,
-                    yvmPath: yvmPath,
+                    yvmPath,
                 }),
             ).toBe(true)
             expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -367,7 +367,7 @@ describe('alias util', () => {
                 await alias.unsetAlias({
                     name: 'two',
                     force: true,
-                    yvmPath: yvmPath,
+                    yvmPath,
                 }),
             ).toBe(true)
             delete mockAliases.two

--- a/test/util/alias.test.js
+++ b/test/util/alias.test.js
@@ -15,6 +15,7 @@ import * as alias from 'util/alias'
 
 describe('alias util', () => {
     const yvmPath = '/Users/tophat/.yvm'
+    jest.spyOn(log, 'info')
 
     afterAll(jest.restoreAllMocks)
 
@@ -64,6 +65,15 @@ describe('alias util', () => {
 
         afterAll(() => {
             mockFS.restore()
+        })
+
+        it('returns nothing if yarn executable fails to run', async () => {
+            const mockError = new Error('not executable')
+            childProcess.execSync.mockImplementationOnce(() => {
+                throw mockError
+            })
+            expect(await alias.resolveSystem()).toEqual(alias.NOT_AVAILABLE)
+            expect(log.info).toHaveBeenCalledWith(mockError.message)
         })
 
         it('gets first non yvm yarn executable', async () => {

--- a/test/util/alias.test.js
+++ b/test/util/alias.test.js
@@ -2,6 +2,10 @@ import fs from 'fs'
 import mockFS from 'mock-fs'
 import childProcess from 'child_process'
 jest.spyOn(childProcess, 'execSync')
+import * as mockProps from 'jest-mock-props'
+mockProps.extend(jest)
+const pathSpy = jest.spyOnProp(process.env, 'PATH')
+const fishUserPathSpy = jest.spyOnProp(process.env, 'fish_user_path')
 
 import log from 'util/log'
 import * as utils from 'util/utils'
@@ -10,6 +14,8 @@ jest.spyOn(utils, 'getVersionsFromTags')
 import * as alias from 'util/alias'
 
 describe('alias', () => {
+    const yvmPath = '/Users/tophat/.yvm'
+
     afterAll(jest.restoreAllMocks)
 
     describe('resolveLatest', () => {
@@ -43,53 +49,56 @@ describe('alias', () => {
     })
 
     describe('resolveSystem', () => {
-        const yvmPath = '/Users/tophat/.yvm'
+        beforeAll(() => {
+            log()
+            mockFS({
+                '/usr/local/bin/yarn': 'mock exec',
+            })
+        })
 
         afterEach(() => {
             alias.resolveSystem.cache.clear()
+            jest.resetAllMocks()
+        })
+
+        afterAll(() => {
+            mockFS.restore()
         })
 
         it('gets first non yvm yarn executable', async () => {
-            const oldPath = process.env.PATH
-            process.env.PATH = `${yvmPath}/versions/v1.13.0/bin:/usr/local/bin:`
+            pathSpy.mockValue(`${yvmPath}/versions/v1.13.0/bin:/usr/local/bin:`)
             childProcess.execSync.mockReturnValueOnce('1.14.0')
-            expect(await alias.resolveSystem({ yvmPath })).toEqual('1.14.0')
+            expect(await alias.resolveSystem()).toEqual('1.14.0')
             expect(childProcess.execSync).toHaveBeenCalledWith(
                 expect.stringContaining('usr/local/bin/yarn'),
             )
-            process.env.PATH = oldPath
         })
 
         it('returns nothing if yarn not found in path', async () => {
-            const oldPath = process.env.PATH
-            process.env.PATH = '/Users/tophat/.nvm/versions/node/v6.11.5/bin:'
-            expect(await alias.resolveSystem({ yvmPath })).toEqual(
-                alias.NOT_AVAILABLE,
-            )
-            process.env.PATH = oldPath
+            pathSpy.mockValue('/Users/tophat/.nvm/versions/node/v6.11.5/bin:')
+            expect(await alias.resolveSystem()).toEqual(alias.NOT_AVAILABLE)
         })
 
         it('gets first non yvm yarn executable in fish shell', async () => {
-            const yvmPath = '/Users/tophat/.yvm'
-            const oldPath = process.env.fish_user_paths
-            process.env.fish_user_paths = `${yvmPath}/versions/v1.13.0/bin /usr/local/bin:`
+            fishUserPathSpy.mockValue(
+                `${yvmPath}/versions/v1.13.0/bin /usr/local/bin:`,
+            )
             childProcess.execSync.mockReturnValueOnce('1.14.0')
-            expect(
-                await alias.resolveSystem({ shell: 'fish', yvmPath }),
-            ).toEqual('1.14.0')
+            expect(await alias.resolveSystem({ shell: 'fish' })).toEqual(
+                '1.14.0',
+            )
             expect(childProcess.execSync).toHaveBeenCalledWith(
                 expect.stringContaining('usr/local/bin/yarn'),
             )
-            process.env.fish_user_paths = oldPath
         })
 
         it('returns nothing if yarn not found in fish user path', async () => {
             const oldPath = process.env.fish_user_paths
             process.env.fish_user_paths =
                 '/Users/tophat/.nvm/versions/node/v6.11.5/bin '
-            expect(
-                await alias.resolveSystem({ shell: 'fish', yvmPath }),
-            ).toEqual(alias.NOT_AVAILABLE)
+            expect(await alias.resolveSystem({ shell: 'fish' })).toEqual(
+                alias.NOT_AVAILABLE,
+            )
             process.env.fish_user_paths = oldPath
         })
     })
@@ -105,8 +114,7 @@ describe('alias', () => {
     })
 
     describe('getUserAliases', () => {
-        const mockYVMPath = '/Users/tophat/.yvm'
-        const aliasesPath = `${mockYVMPath}/${alias.STORAGE_FILE}`
+        const aliasesPath = `${yvmPath}/${alias.STORAGE_FILE}`
         beforeEach(() => {
             log()
             mockFS({
@@ -120,7 +128,7 @@ describe('alias', () => {
         })
 
         it('sets default to stable', async () => {
-            expect(await alias.getUserAliases(mockYVMPath)).toEqual({
+            expect(await alias.getUserAliases(yvmPath)).toEqual({
                 [alias.DEFAULT]: alias.STABLE,
             })
         })
@@ -130,7 +138,7 @@ describe('alias', () => {
             mockFS({
                 [aliasesPath]: `{"default":"${mockDefaultAlias}"}`,
             })
-            expect(await alias.getUserAliases(mockYVMPath)).toEqual({
+            expect(await alias.getUserAliases(yvmPath)).toEqual({
                 [alias.DEFAULT]: mockDefaultAlias,
             })
         })
@@ -139,7 +147,7 @@ describe('alias', () => {
             mockFS({
                 [aliasesPath]: `"default":"testing"`,
             })
-            expect(await alias.getUserAliases(mockYVMPath)).toEqual({
+            expect(await alias.getUserAliases(yvmPath)).toEqual({
                 [alias.DEFAULT]: alias.STABLE,
             })
         })
@@ -158,7 +166,7 @@ describe('alias', () => {
                     [aliasesPath]: JSON.stringify(mockAliases),
                 })
                 expect(
-                    await alias.getMatchingAliases(undefined, mockYVMPath),
+                    await alias.getMatchingAliases(undefined, yvmPath),
                 ).toEqual(expectedAliases)
             })
 
@@ -171,16 +179,15 @@ describe('alias', () => {
                 mockFS({
                     [aliasesPath]: JSON.stringify(mockAliases),
                 })
-                expect(
-                    await alias.getMatchingAliases('oth', mockYVMPath),
-                ).toEqual(expectedAliases)
+                expect(await alias.getMatchingAliases('oth', yvmPath)).toEqual(
+                    expectedAliases,
+                )
             })
         })
     })
 
     describe('setAlias', () => {
-        const mockYVMPath = '/Users/tophat/.yvm'
-        const aliasesPath = `${mockYVMPath}/${alias.STORAGE_FILE}`
+        const aliasesPath = `${yvmPath}/${alias.STORAGE_FILE}`
         jest.spyOn(log, 'default')
         beforeEach(() => {
             log()
@@ -199,10 +206,10 @@ describe('alias', () => {
                 await alias.setAlias({
                     name: 'test',
                     version: '1.7.0',
-                    yvmPath: mockYVMPath,
+                    yvmPath: yvmPath,
                 }),
             ).toBe(true)
-            expect(await alias.getUserAliases(mockYVMPath)).toEqual({
+            expect(await alias.getUserAliases(yvmPath)).toEqual({
                 [alias.DEFAULT]: alias.STABLE,
                 test: '1.7.0',
             })
@@ -215,7 +222,7 @@ describe('alias', () => {
                     await alias.setAlias({
                         name: alias.STABLE,
                         version: '1.7.0',
-                        yvmPath: mockYVMPath,
+                        yvmPath: yvmPath,
                     }),
                 ).toBe(false)
                 expect(log.default).toHaveBeenCalledWith(
@@ -226,8 +233,7 @@ describe('alias', () => {
     })
 
     describe('unsetAlias', () => {
-        const mockYVMPath = '/Users/tophat/.yvm'
-        const aliasesPath = `${mockYVMPath}/${alias.STORAGE_FILE}`
+        const aliasesPath = `${yvmPath}/${alias.STORAGE_FILE}`
         jest.spyOn(fs, 'writeFileSync')
         jest.spyOn(log, 'default')
 
@@ -251,7 +257,7 @@ describe('alias', () => {
             expect(
                 await alias.unsetAlias({
                     name: alias.STABLE,
-                    yvmPath: mockYVMPath,
+                    yvmPath: yvmPath,
                 }),
             ).toBe(false)
             expect(log.default).toHaveBeenCalledWith(
@@ -267,11 +273,11 @@ describe('alias', () => {
                     zero: '1.7.0',
                 }),
             })
-            await alias.getUserAliases(mockYVMPath)
+            await alias.getUserAliases(yvmPath)
             expect(
                 await alias.unsetAlias({
                     name: 'zero',
-                    yvmPath: mockYVMPath,
+                    yvmPath: yvmPath,
                 }),
             ).toBe(false)
             expect(fs.writeFileSync).not.toHaveBeenCalled()
@@ -290,12 +296,12 @@ describe('alias', () => {
                     zero: '1.7.0',
                 }),
             })
-            const mockAliases = await alias.getUserAliases(mockYVMPath)
+            const mockAliases = await alias.getUserAliases(yvmPath)
             expect(
                 await alias.unsetAlias({
                     name: 'zero',
                     force: true,
-                    yvmPath: mockYVMPath,
+                    yvmPath: yvmPath,
                 }),
             ).toBe(true)
             delete mockAliases.zero
@@ -313,12 +319,12 @@ describe('alias', () => {
                     zero: '1.7.0',
                 }),
             })
-            await alias.getUserAliases(mockYVMPath)
+            await alias.getUserAliases(yvmPath)
             expect(
                 await alias.unsetAlias({
                     name: 'zero',
                     recursive: true,
-                    yvmPath: mockYVMPath,
+                    yvmPath: yvmPath,
                 }),
             ).toBe(true)
             expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -339,7 +345,7 @@ describe('alias', () => {
                 await alias.unsetAlias({
                     name: 'zero',
                     recursive: true,
-                    yvmPath: mockYVMPath,
+                    yvmPath: yvmPath,
                 }),
             ).toBe(true)
             expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -356,12 +362,12 @@ describe('alias', () => {
                     zero: '1.7.0',
                 }),
             })
-            const mockAliases = await alias.getUserAliases(mockYVMPath)
+            const mockAliases = await alias.getUserAliases(yvmPath)
             expect(
                 await alias.unsetAlias({
                     name: 'two',
                     force: true,
-                    yvmPath: mockYVMPath,
+                    yvmPath: yvmPath,
                 }),
             ).toBe(true)
             delete mockAliases.two
@@ -373,8 +379,7 @@ describe('alias', () => {
     })
 
     describe('resolveAliases', () => {
-        const mockYVMPath = '/Users/tophat/.yvm'
-        const aliasesPath = `${mockYVMPath}/${alias.STORAGE_FILE}`
+        const aliasesPath = `${yvmPath}/${alias.STORAGE_FILE}`
         jest.spyOn(fs, 'writeFileSync')
         jest.spyOn(log, 'default')
 
@@ -404,7 +409,7 @@ describe('alias', () => {
             })
             const result = await alias.resolveMatchingAliases(
                 undefined,
-                mockYVMPath,
+                yvmPath,
             )
             mockFS.restore()
             expect(result).toMatchSnapshot()
@@ -420,7 +425,7 @@ describe('alias', () => {
             })
             const result = await alias.resolveMatchingAliases(
                 undefined,
-                mockYVMPath,
+                yvmPath,
             )
             mockFS.restore()
             expect(result).toMatchSnapshot()
@@ -435,9 +440,9 @@ describe('alias', () => {
                     zero: version,
                 }),
             })
-            expect(
-                await alias.resolveMatchingAliases('one', mockYVMPath),
-            ).toEqual([{ name: 'one', value: { value: 'zero', version } }])
+            expect(await alias.resolveMatchingAliases('one', yvmPath)).toEqual([
+                { name: 'one', value: { value: 'zero', version } },
+            ])
         })
 
         it('returns not available when unable to resolve reserved', async () => {

--- a/test/util/alias.test.js
+++ b/test/util/alias.test.js
@@ -5,7 +5,7 @@ jest.spyOn(childProcess, 'execSync')
 import * as mockProps from 'jest-mock-props'
 mockProps.extend(jest)
 const pathSpy = jest.spyOnProp(process.env, 'PATH')
-const fishUserPathSpy = jest.spyOnProp(process.env, 'fish_user_path')
+const fishUserPathSpy = jest.spyOnProp(process.env, 'fish_user_paths')
 
 import log from 'util/log'
 import * as utils from 'util/utils'

--- a/test/util/alias.test.js
+++ b/test/util/alias.test.js
@@ -13,7 +13,7 @@ jest.spyOn(utils, 'getRequest')
 jest.spyOn(utils, 'getVersionsFromTags')
 import * as alias from 'util/alias'
 
-describe('alias', () => {
+describe('alias util', () => {
     const yvmPath = '/Users/tophat/.yvm'
 
     afterAll(jest.restoreAllMocks)


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Update current command to detect shimmed yarn
- Update alias command to use the helper methods

### Checklist
- [x] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- `yvm current` does not detect yarn shim version
- Please `make install`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- `yvm current` should show correct output
- `yvm alias` should show yvm aliases

### Comments
<!-- Any other comments you want to include for reviewers. -->
