### PR TITLE
feat: support configurable shell profiles

### DIFF
--- a/.github/tap-release.yml
+++ b/.github/tap-release.yml
@@ -39,7 +39,7 @@ template: >
     def caveats
       emptor = <<~EOS
         Run the following command to configure your shell rc file
-        $ YVM_INSTALL_DIR="#{prefix}" node "#{prefix}/yvm.js" configure-shell
+        $ node "#{prefix}/yvm.js" configure-shell --yvmDir "#{prefix}"
 
         If you have previously installed YVM, link the versions folder
         to allow all brewed YVM access to the managed yarn distributions

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -13,6 +13,7 @@ const releaseAssetsByPreference = [binFile, zipFile]
 
 function getConfig() {
     const home = process.env.HOME || os.homedir()
+    const profile = process.env.PROFILE || null
     const useLocal = process.env.USE_LOCAL || false
     const yvmDir = process.env.YVM_INSTALL_DIR || path.join(home, '.yvm')
     const yvmGateway = 'https://d236jo9e8rrdox.cloudfront.net'
@@ -20,6 +21,7 @@ function getConfig() {
     return {
         paths: {
             home,
+            profile,
             yvm: yvmDir,
         },
         releaseApiUrl,
@@ -265,14 +267,13 @@ async function run() {
         ongoingTasks.push(saveVersion(version.tagName, paths.yvm))
     }
     try {
-        const configureCommand = [
-            'node',
-            yvmBinFile,
-            'configure-shell',
-            '--home',
-            paths.home,
-        ].join(' ')
-        execSync(configureCommand)
+        const configureCommand = ['node', yvmBinFile, 'configure-shell']
+        configureCommand.push('--home', paths.home)
+        configureCommand.push('--yvmDir', paths.yvm)
+        if (paths.profile) {
+            configureCommand.push('--profile', paths.profile)
+        }
+        execSync(configureCommand.join(' '))
     } catch (e) {
         log('Unable to configure shell')
     }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -266,15 +266,24 @@ async function run() {
     if (version.tagName) {
         ongoingTasks.push(saveVersion(version.tagName, paths.yvm))
     }
-    try {
-        const configureCommand = ['node', yvmBinFile, 'configure-shell']
-        configureCommand.push('--home', paths.home)
-        configureCommand.push('--yvmDir', paths.yvm)
-        if (paths.profile) {
-            configureCommand.push('--profile', paths.profile)
+    const configureCommand = ['node', yvmBinFile, 'configure-shell']
+    if (paths.home) configureCommand.push('--home', paths.home)
+    if (paths.profile) configureCommand.push('--profile', paths.profile)
+    // Run without --yvmDir flag for n-1 compatibility
+    const commandStrings = [configureCommand.join(' ')]
+    if (paths.yvm) configureCommand.push('--yvmDir', paths.yvm)
+    commandStrings.unshift(configureCommand.join(' '))
+    let configured = false
+    for (const cmd of commandStrings) {
+        try {
+            execSync(cmd)
+            configured = true
+            break
+        } catch (e) {
+            continue
         }
-        execSync(configureCommand.join(' '))
-    } catch (e) {
+    }
+    if (!configured) {
         log('Unable to configure shell')
     }
     await Promise.all(ongoingTasks)

--- a/src/commands/configureShell.js
+++ b/src/commands/configureShell.js
@@ -49,7 +49,7 @@ export async function ensureConfig(configFile, configLines) {
 const yvmDirVarName = 'YVM_DIR'
 
 export const configureBash = async ({ home, profile, yvmDir }) => {
-    const profiles = [
+    const configFiles = [
         profile,
         path.join(home, '.bashrc'),
         path.join(home, '.bash_profile'),
@@ -60,12 +60,12 @@ export const configureBash = async ({ home, profile, yvmDir }) => {
         `export ${yvmDirVarName}=${yvmDir}`,
         `[ -r $${shPathVariable} ] && . $${shPathVariable}`,
     ]
-    for (const file of profiles) {
-        if (fs.existsSync(file) && (await ensureConfig(file, bashConfig))) {
+    for (const file of configFiles) {
+        if (await ensureConfig(file, bashConfig)) {
             return unpackShellScript(bashScript, path.join(yvmDir, shFile))
         }
     }
-    log('Unable to configure BASH at', profiles.join(' or '))
+    log('Unable to configure BASH at', configFiles.join(' or '))
 }
 
 export const configureFish = async ({ home, profile, yvmDir }) => {
@@ -79,13 +79,11 @@ export const configureFish = async ({ home, profile, yvmDir }) => {
         `. $${path.join(yvmDirVarName, fishFile)}`,
     ]
     for (const file of configFiles) {
-        const configured = await ensureConfig(file, fishConfig)
-        if (!configured) {
-            log('Unable to configure FISH at', file)
-            return false
+        if (await ensureConfig(file, fishConfig)) {
+            return unpackShellScript(fishScript, path.join(yvmDir, fishFile))
         }
-        return unpackShellScript(fishScript, path.join(yvmDir, fishFile))
     }
+    log('Unable to configure FISH at', configFiles.join(' or '))
 }
 
 export const configureZsh = async ({ home, profile, yvmDir }) => {
@@ -97,13 +95,11 @@ export const configureZsh = async ({ home, profile, yvmDir }) => {
         `[ -r $${shPathVariable} ] && . $${shPathVariable}`,
     ]
     for (const file of configFiles) {
-        const configured = await ensureConfig(file, zshConfig)
-        if (!configured) {
-            log('Unable to configure ZSH at', file)
-            return false
+        if (await ensureConfig(file, zshConfig)) {
+            return unpackShellScript(bashScript, path.join(yvmDir, zshFile))
         }
-        return unpackShellScript(bashScript, path.join(yvmDir, zshFile))
     }
+    log('Unable to configure ZSH at', configFiles.join(' or '))
 }
 
 export const configureShim = async ({ yvmDir }) => {

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -149,13 +149,14 @@ argParser
     .command('configure-shell', '', { noHelp: true })
     .option('--home [home]', 'Alternate path to home directory')
     .option('--shell [shell]', 'Shell to configure, defaults to all')
+    .option('--profile [profile]', 'Alternate path to shell profile')
     .option('--no-shim', 'Skips yarn shim')
     .description(
         'Internal command: Configures any shell config files found for loading yvm on startup',
     )
-    .action(async ({ home, shell, shim }) => {
+    .action(async config => {
         const { configureShell } = await import('commands/configureShell')
-        process.exit(await configureShell({ home, shell, shim }))
+        process.exit(await configureShell(config))
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -150,6 +150,7 @@ argParser
     .option('--home [home]', 'Alternate path to home directory')
     .option('--shell [shell]', 'Shell to configure, defaults to all')
     .option('--profile [profile]', 'Alternate path to shell profile')
+    .option('--yvmDir [yvmDir]', 'Alternate path to yvm install path')
     .option('--no-shim', 'Skips yarn shim')
     .description(
         'Internal command: Configures any shell config files found for loading yvm on startup',

--- a/test/commands/__snapshots__/configureShell.test.js.snap
+++ b/test/commands/__snapshots__/configureShell.test.js.snap
@@ -30,16 +30,16 @@ Object {
 exports[`configureShell configures none 2`] = `
 Array [
   Array [
-    "Unable to configure BASH at",
-    "config-mock-home/.bashrc or config-mock-home/.bash_profile",
-  ],
-  Array [
     "Unable to configure FISH at",
     "config-mock-home/.config/fish/config.fish",
   ],
   Array [
     "Unable to configure ZSH at",
     "config-mock-home/.zshrc",
+  ],
+  Array [
+    "Unable to configure BASH at",
+    "config-mock-home/.bashrc or config-mock-home/.bash_profile",
   ],
 ]
 `;

--- a/test/commands/__snapshots__/configureShell.test.js.snap
+++ b/test/commands/__snapshots__/configureShell.test.js.snap
@@ -31,9 +31,7 @@ exports[`configureShell configures none 2`] = `
 Array [
   Array [
     "Unable to configure BASH at",
-    "config-mock-home/.bashrc",
-    "or",
-    "config-mock-home/.bash_profile",
+    "config-mock-home/.bashrc or config-mock-home/.bash_profile",
   ],
   Array [
     "Unable to configure FISH at",

--- a/test/commands/__snapshots__/configureShell.test.js.snap
+++ b/test/commands/__snapshots__/configureShell.test.js.snap
@@ -11,10 +11,24 @@ export YVM_DIR=config-mock-home/.yvm
 set -x YVM_DIR config-mock-home/.yvm
 . $YVM_DIR/yvm.fish
 ",
+  "config-mock-home/.custom_profile": "dummy",
   "config-mock-home/.zshrc": "dummy
 export YVM_DIR=config-mock-home/.yvm
 [ -r $YVM_DIR/yvm.sh ] && . $YVM_DIR/yvm.sh
 ",
+}
+`;
+
+exports[`configureShell configures custom profile 1`] = `
+Object {
+  "config-mock-home/.bash_profile": "dummy",
+  "config-mock-home/.bashrc": "dummy",
+  "config-mock-home/.config/fish/config.fish": "dummy",
+  "config-mock-home/.custom_profile": "dummy
+export YVM_DIR=config-mock-install-dir/.yvm
+[ -r $YVM_DIR/yvm.sh ] && . $YVM_DIR/yvm.sh
+",
+  "config-mock-home/.zshrc": "dummy",
 }
 `;
 
@@ -23,6 +37,7 @@ Object {
   "config-mock-home/.bash_profile": null,
   "config-mock-home/.bashrc": null,
   "config-mock-home/.config/fish/config.fish": null,
+  "config-mock-home/.custom_profile": null,
   "config-mock-home/.zshrc": null,
 }
 `;
@@ -52,6 +67,7 @@ export YVM_DIR=config-mock-install-dir/.yvm
 ",
   "config-mock-home/.bashrc": null,
   "config-mock-home/.config/fish/config.fish": "dummy",
+  "config-mock-home/.custom_profile": "dummy",
   "config-mock-home/.zshrc": "dummy",
 }
 `;
@@ -64,6 +80,7 @@ export YVM_DIR=config-mock-install-dir/.yvm
 [ -r $YVM_DIR/yvm.sh ] && . $YVM_DIR/yvm.sh
 ",
   "config-mock-home/.config/fish/config.fish": "dummy",
+  "config-mock-home/.custom_profile": "dummy",
   "config-mock-home/.zshrc": "dummy",
 }
 `;
@@ -76,6 +93,7 @@ Object {
 set -x YVM_DIR config-mock-home/.yvm
 . $YVM_DIR/yvm.fish
 ",
+  "config-mock-home/.custom_profile": "dummy",
   "config-mock-home/.zshrc": "dummy",
 }
 `;
@@ -85,6 +103,7 @@ Object {
   "config-mock-home/.bash_profile": "dummy",
   "config-mock-home/.bashrc": "dummy",
   "config-mock-home/.config/fish/config.fish": "dummy",
+  "config-mock-home/.custom_profile": "dummy",
   "config-mock-home/.zshrc": "dummy
 export YVM_DIR=config-mock-home/.yvm
 [ -r $YVM_DIR/yvm.sh ] && . $YVM_DIR/yvm.sh

--- a/test/commands/configureShell.test.js
+++ b/test/commands/configureShell.test.js
@@ -9,9 +9,9 @@ import { configureShell, ensureConfig } from 'commands/configureShell'
 
 describe('configureShell', () => {
     const mockHomeValue = 'config-mock-home'
+    const yvmDir = `${mockHomeValue}/.yvm`
     const envHomeMock = jest.spyOnProp(process.env, 'HOME')
     const mockInstallDir = 'config-mock-install-dir/.yvm'
-    const envYvmInstallDir = jest.spyOnProp(process.env, 'YVM_INSTALL_DIR')
     jest.spyOn(os, 'homedir')
     jest.spyOn(log, 'default')
     jest.spyOn(log, 'info')
@@ -45,16 +45,18 @@ describe('configureShell', () => {
 
     afterEach(() => {
         envHomeMock.mockReset()
-        envYvmInstallDir.mockReset()
         vol.reset()
     })
 
     afterAll(jest.restoreAllMocks)
 
     it('configures only bashrc', async () => {
-        envYvmInstallDir.mockValue(mockInstallDir)
         expect(
-            await configureShell({ home: mockHomeValue, shell: 'bash' }),
+            await configureShell({
+                home: mockHomeValue,
+                shell: 'bash',
+                yvmDir: mockInstallDir,
+            }),
         ).toBe(0)
         confirmShellConfig()
         expect(log.info).toHaveBeenCalledWith(
@@ -69,10 +71,13 @@ describe('configureShell', () => {
     })
 
     it('configures only bash_profile when no bashrc', async () => {
-        envYvmInstallDir.mockValue(mockInstallDir)
         fs.unlinkSync(rcFiles.bashrc)
         expect(
-            await configureShell({ home: mockHomeValue, shell: 'bash' }),
+            await configureShell({
+                home: mockHomeValue,
+                shell: 'bash',
+                yvmDir: mockInstallDir,
+            }),
         ).toBe(0)
         confirmShellConfig()
         expect(log.info).toHaveBeenCalledWith(
@@ -88,7 +93,12 @@ describe('configureShell', () => {
 
     it('configures only fish', async () => {
         envHomeMock.mockValue(mockHomeValue)
-        expect(await configureShell({ shell: 'fish' })).toBe(0)
+        expect(
+            await configureShell({
+                shell: 'fish',
+                yvmDir: `${mockHomeValue}/.yvm`,
+            }),
+        ).toBe(0)
         confirmShellConfig()
         expect(log.info).toHaveBeenCalledWith(
             expect.stringContaining('Configured'),
@@ -104,7 +114,7 @@ describe('configureShell', () => {
     it('configures only zsh', async () => {
         envHomeMock.mockValue()
         os.homedir.mockReturnValueOnce(mockHomeValue)
-        expect(await configureShell({ shell: 'zsh' })).toBe(0)
+        expect(await configureShell({ shell: 'zsh', yvmDir })).toBe(0)
         confirmShellConfig()
         expect(log.info).toHaveBeenCalledWith(
             expect.stringContaining('Configured'),
@@ -118,7 +128,7 @@ describe('configureShell', () => {
     })
 
     it('configures all', async () => {
-        expect(await configureShell({ home: mockHomeValue })).toBe(0)
+        expect(await configureShell({ home: mockHomeValue, yvmDir })).toBe(0)
         confirmShellConfig()
         expect(log.info).toHaveBeenCalledWith(
             expect.stringContaining('Configured'),

--- a/test/commands/configureShell.test.js
+++ b/test/commands/configureShell.test.js
@@ -93,12 +93,7 @@ describe('configureShell', () => {
 
     it('configures only fish', async () => {
         envHomeMock.mockValue(mockHomeValue)
-        expect(
-            await configureShell({
-                shell: 'fish',
-                yvmDir: `${mockHomeValue}/.yvm`,
-            }),
-        ).toBe(0)
+        expect(await configureShell({ shell: 'fish', yvmDir })).toBe(0)
         confirmShellConfig()
         expect(log.info).toHaveBeenCalledWith(
             expect.stringContaining('Configured'),

--- a/test/commands/configureShell.test.js
+++ b/test/commands/configureShell.test.js
@@ -18,6 +18,7 @@ describe('configureShell', () => {
 
     const fileToPath = ([file]) => path.join(mockHomeValue, file)
     const rcFiles = {
+        custom: fileToPath`.custom_profile`,
         bashrc: fileToPath`.bashrc`,
         bashpro: fileToPath`.bash_profile`,
         zshrc: fileToPath`.zshrc`,
@@ -36,6 +37,7 @@ describe('configureShell', () => {
         jest.clearAllMocks()
         const dummyContent = 'dummy'
         vol.fromJSON({
+            [rcFiles.custom]: dummyContent,
             [rcFiles.bashrc]: dummyContent,
             [rcFiles.bashpro]: dummyContent,
             [rcFiles.zshrc]: dummyContent,
@@ -49,6 +51,26 @@ describe('configureShell', () => {
     })
 
     afterAll(jest.restoreAllMocks)
+
+    it('configures custom profile', async () => {
+        expect(
+            await configureShell({
+                shell: 'bash',
+                profile: fileToPath`.custom_profile`,
+                yvmDir: mockInstallDir,
+            }),
+        ).toBe(0)
+        confirmShellConfig()
+        expect(log.info).toHaveBeenCalledWith(
+            expect.stringContaining('Configured'),
+        )
+        expect(log.info).toHaveBeenCalledWith(
+            expect.stringContaining(rcFiles.custom),
+        )
+        expect(log.default).toHaveBeenCalledWith(
+            'Shell configured successfully',
+        )
+    })
 
     it('configures only bashrc', async () => {
         expect(

--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -25,7 +25,7 @@ const clearYvmCommands = [
 ]
 const configureYvmCmd = linkCommands(
     fileExists(yvmBinFile),
-    `YVM_INSTALL_DIR="${yvmDir}" node ${yvmBinFile} configure-shell`,
+    `node ${yvmBinFile} configure-shell --yvmDir "${yvmDir}"`,
 )
 const installYVMPlugin = new WebpackCompilerPlugin({
     name: 'install-yvm-plugin',


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
Fixes #427

### Checklist
- [x] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Please `make install`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- `yvm configure-shell --shell bash --profile ~/.noprofile --yvmDir somerandom/.yvm`
  - should fallback to configuring your `.bashrc` or `.bash_profile`
  - should create a `somerandom/.yvm` dir with `yvm.sh` and `shim` unpacked
- `touch ~/.noprofile`
- `yvm configure-shell --shell bash --profile ~/.noprofile --yvmDir somerandom/.yvm`
  - should configure the `~/.noprofile` with the yvm initialisation
  - should create a `somerandom/.yvm` dir with `yvm.sh` and `shim` unpacked

### Comments
<!-- Any other comments you want to include for reviewers. -->
