### PR TITLE
fix: pin install version in legacy shell install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.js | node
+curl -fsSL https://raw.githubusercontent.com/tophat/yvm/${INSTALL_VERSION:-master}/scripts/install.js | node


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Pin the yvm version install js being installed

### Checklist
- [ ] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA
- N/A

### Comments
<!-- Any other comments you want to include for reviewers. -->
