### PR TITLE
fix: match version tags with v prefix in install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR?=$(ARTIFACT_DIR)/webpack_build
 ifdef CI
     ESLINT_EXTRA_ARGS=--format junit --output-file $(TEST_REPORTS_DIR)/lint/eslint.junit.xml
     JEST_ENV_VARIABLES=JEST_SUITE_NAME=yvm JEST_JUNIT_OUTPUT=$(TEST_REPORTS_DIR)/tests/jest.junit.xml
-    JEST_ARGS=--ci --maxWorkers=2 --reporters jest-junit
+    JEST_ARGS=--ci --maxWorkers=2 --testResultsProcessor jest-junit
     WEBPACK_ARGS=
     YARN_INSTALL_ARGS=--pure-lockfile --ci
 else

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR?=$(ARTIFACT_DIR)/webpack_build
 ifdef CI
     ESLINT_EXTRA_ARGS=--format junit --output-file $(TEST_REPORTS_DIR)/lint/eslint.junit.xml
     JEST_ENV_VARIABLES=JEST_SUITE_NAME=yvm JEST_JUNIT_OUTPUT=$(TEST_REPORTS_DIR)/tests/jest.junit.xml
-    JEST_ARGS=--ci --maxWorkers=2 --testResultsProcessor jest-junit
+    JEST_ARGS=--ci --maxWorkers=2 --reporters=default --reporters=jest-junit
     WEBPACK_ARGS=
     YARN_INSTALL_ARGS=--pure-lockfile --ci
 else

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -66,7 +66,8 @@ function getTagAndUrlFromRelease(data) {
     }
 }
 
-async function getYvmVersion(versionTag, releasesApiUrl) {
+async function getYvmVersion(version, releasesApiUrl) {
+    const versionTag = version.startsWith('v') ? version : `v${version}`
     const data = await downloadFile({ source: releasesApiUrl })
     for (const release of JSON.parse(data)) {
         const { tagName } = getTagAndUrlFromRelease(release)

--- a/test/scripts/install.test.js
+++ b/test/scripts/install.test.js
@@ -339,7 +339,7 @@ describe('install yvm', () => {
 
             // creates version tag
             const { version } = fs.readJsonSync(`${yvmHome}/.version`)
-            expect(version).toMatch(installVersion)
+            expect(version.substring(1).startsWith(installVersion)).toBe(true)
         }
 
         it.each(['v2.3.0', '2.4'].map(a => [a]))(

--- a/test/scripts/install.test.js
+++ b/test/scripts/install.test.js
@@ -303,51 +303,46 @@ describe('install yvm', () => {
             fs.removeSync(mockHome)
         })
 
-        const testFn = async installVersion => {
-            envInstallVersion.mockValue(installVersion)
-            const config = getConfig()
-            expect(config).toMatchObject(
-                expectedConfigObject({
-                    homePath: mockHome,
-                    useLocal: false,
-                    tagName: installVersion,
-                }),
-            )
-            await run()
-            const yvmHome = config.paths.yvm
-            const expectedOutput = [
-                'Installing Version',
-                'yvm successfully installed',
-                `source ${yvmHome}`,
-            ]
-            expectedOutput.forEach(output =>
-                expect(log).toHaveBeenCalledWith(
-                    expect.stringContaining(output),
-                ),
-            )
-            const installFiles = [
-                ['yvm.sh', true],
-                ['yvm.js', false],
-                ['yvm.fish', false],
-            ]
-            installFiles.forEach(([file, isExecutable]) => {
-                const filePath = `${yvmHome}/${file}`
-                expect(filePath).toBeExistingFile()
-                // script is executable
-                if (isExecutable) fs.accessSync(filePath, fs.constants.X_OK)
-            })
-
-            // creates version tag
-            const { version } = fs.readJsonSync(`${yvmHome}/.version`)
-            const versionToMatch = installVersion.startsWith('v')
-                ? installVersion
-                : `v${installVersion}`
-            expect(version).toMatch(versionToMatch)
-        }
-
-        it.each(['v2.3.0', '2.4'].map(a => [a]))(
+        it.each([['v2.3.0', 'v2.3.0'], ['2.4', 'v2.4.3']])(
             'indicates successful completion %s',
-            testFn,
+            async (installVersion, versionToMatch) => {
+                envInstallVersion.mockValue(installVersion)
+                const config = getConfig()
+                expect(config).toMatchObject(
+                    expectedConfigObject({
+                        homePath: mockHome,
+                        useLocal: false,
+                        tagName: installVersion,
+                    }),
+                )
+                await run()
+                const yvmHome = config.paths.yvm
+                const expectedOutput = [
+                    'Installing Version',
+                    'yvm successfully installed',
+                    `source ${yvmHome}`,
+                ]
+                expectedOutput.forEach(output =>
+                    expect(log).toHaveBeenCalledWith(
+                        expect.stringContaining(output),
+                    ),
+                )
+                const installFiles = [
+                    ['yvm.sh', true],
+                    ['yvm.js', false],
+                    ['yvm.fish', false],
+                ]
+                installFiles.forEach(([file, isExecutable]) => {
+                    const filePath = `${yvmHome}/${file}`
+                    expect(filePath).toBeExistingFile()
+                    // script is executable
+                    if (isExecutable) fs.accessSync(filePath, fs.constants.X_OK)
+                })
+
+                // creates version tag
+                const { version } = fs.readJsonSync(`${yvmHome}/.version`)
+                expect(version).toMatch(versionToMatch)
+            },
         )
     })
 

--- a/test/scripts/install.test.js
+++ b/test/scripts/install.test.js
@@ -339,7 +339,10 @@ describe('install yvm', () => {
 
             // creates version tag
             const { version } = fs.readJsonSync(`${yvmHome}/.version`)
-            expect(version.substring(1).startsWith(installVersion)).toBe(true)
+            const versionToMatch = installVersion.startsWith('v')
+                ? installVersion
+                : `v${installVersion}`
+            expect(version).toMatch(versionToMatch)
         }
 
         it.each(['v2.3.0', '2.4'].map(a => [a]))(


### PR DESCRIPTION
## Description

Fixes the install script to account for "v" prefix

### Checklist
- [ ] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

- `yarn jest scripts/install -t 'specified version'` should install `v2.4.x` not `v3.2.4`
