### PR TITLE
fix: check if yvm script exists in fish shell before sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Remove in `$HOME/.config/fish/config.fish` for fishers:
 
 ```fish
 set -x YVM_DIR /home/joe_user/.yvm
-[ -f $YVM_DIR/yvm.fish ]; and source $YVM_DIR/yvm.fish
+[ -r $YVM_DIR/yvm.fish ]; and source $YVM_DIR/yvm.fish
 ```
 
 In case you had older version of yvm installed, there could also be a line like

--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ Next, edit `$HOME/.bashrc` and `$HOME/.zshrc` and remove those lines:
 
 ```bash
 export YVM_DIR=/home/joe_user/.yvm
-[ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh
+[ -r $YVM_DIR/yvm.sh ] && . $YVM_DIR/yvm.sh
 ```
 
 Remove in `$HOME/.config/fish/config.fish` for fishers:
 
 ```fish
 set -x YVM_DIR /home/joe_user/.yvm
-. $YVM_DIR/yvm.fish
+[ -f $YVM_DIR/yvm.fish ]; and source $YVM_DIR/yvm.fish
 ```
 
 In case you had older version of yvm installed, there could also be a line like

--- a/src/commands/configureShell.js
+++ b/src/commands/configureShell.js
@@ -80,7 +80,7 @@ export const configureFish = async ({ home, profile, yvmDir }) => {
     const fishPathVariable = path.join(yvmDirVarName, fishFile)
     const fishConfig = [
         `set -x ${yvmDirVarName} ${yvmDir}`,
-        `[ -f $${fishPathVariable} ]; and source $${fishPathVariable}`,
+        `[ -r $${fishPathVariable} ]; and source $${fishPathVariable}`,
     ]
     for (const file of configFiles) {
         if (await ensureConfig(file, fishConfig)) {

--- a/src/commands/configureShell.js
+++ b/src/commands/configureShell.js
@@ -77,9 +77,10 @@ export const configureFish = async ({ home, profile, yvmDir }) => {
         path.join(home, '.config', 'fish', 'config.fish'),
     ].filter(Boolean)
     const fishFile = 'yvm.fish'
+    const fishPathVariable = path.join(yvmDirVarName, fishFile)
     const fishConfig = [
         `set -x ${yvmDirVarName} ${yvmDir}`,
-        `. $${path.join(yvmDirVarName, fishFile)}`,
+        `[ -f $${fishPathVariable} ]; and source $${fishPathVariable}`,
     ]
     for (const file of configFiles) {
         if (await ensureConfig(file, fishConfig)) {

--- a/test/commands/__snapshots__/configureShell.test.js.snap
+++ b/test/commands/__snapshots__/configureShell.test.js.snap
@@ -9,7 +9,7 @@ export YVM_DIR=config-mock-home/.yvm
 ",
   "config-mock-home/.config/fish/config.fish": "dummy
 set -x YVM_DIR config-mock-home/.yvm
-. $YVM_DIR/yvm.fish
+[ -r $YVM_DIR/yvm.fish ]; and source $YVM_DIR/yvm.fish
 ",
   "config-mock-home/.custom_profile": "dummy",
   "config-mock-home/.zshrc": "dummy
@@ -26,7 +26,7 @@ Object {
   "config-mock-home/.config/fish/config.fish": "dummy",
   "config-mock-home/.custom_profile": "dummy
 set -x YVM_DIR config-mock-install-dir/.yvm
-. $YVM_DIR/yvm.fish
+[ -r $YVM_DIR/yvm.fish ]; and source $YVM_DIR/yvm.fish
 ",
   "config-mock-home/.zshrc": "dummy",
 }
@@ -104,7 +104,7 @@ Object {
   "config-mock-home/.bashrc": "dummy",
   "config-mock-home/.config/fish/config.fish": "dummy
 set -x YVM_DIR config-mock-home/.yvm
-. $YVM_DIR/yvm.fish
+[ -r $YVM_DIR/yvm.fish ]; and source $YVM_DIR/yvm.fish
 ",
   "config-mock-home/.custom_profile": "dummy",
   "config-mock-home/.zshrc": "dummy",

--- a/test/scripts/install.test.js
+++ b/test/scripts/install.test.js
@@ -215,7 +215,7 @@ describe('install yvm', () => {
             ],
             [`${mockHomeValue}/.config/fish/config.fish`]: [
                 `set -x YVM_DIR ${mockHomeValue}/.yvm`,
-                '. $YVM_DIR/yvm.fish',
+                '[ -r $YVM_DIR/yvm.fish ]; and source $YVM_DIR/yvm.fish',
             ],
             [`${mockHomeValue}/.zshrc`]: [
                 `export YVM_DIR=${mockHomeValue}/.yvm`,
@@ -303,10 +303,7 @@ describe('install yvm', () => {
             fs.removeSync(mockHome)
         })
 
-        it.each([
-            ['v2.3.0', 'v2.3.0'],
-            ['2.4', 'v2.4.3'],
-        ])(
+        it.each([['v2.3.0', 'v2.3.0'], ['2.4', 'v2.4.3']])(
             'indicates successful completion %s',
             async (installVersion, versionToMatch) => {
                 envInstallVersion.mockValue(installVersion)

--- a/test/scripts/install.test.js
+++ b/test/scripts/install.test.js
@@ -303,7 +303,10 @@ describe('install yvm', () => {
             fs.removeSync(mockHome)
         })
 
-        it.each([['v2.3.0', 'v2.3.0'], ['2.4', 'v2.4.3']])(
+        it.each([
+            ['v2.3.0', 'v2.3.0'],
+            ['2.4', 'v2.4.3'],
+        ])(
             'indicates successful completion %s',
             async (installVersion, versionToMatch) => {
                 envInstallVersion.mockValue(installVersion)


### PR DESCRIPTION
## Description

Fix fish shell config to check for the existence of the file before sourcing it

### Checklist
- [x] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

- `make install`
- Load fish shell
- `yvm ls-remote`
- Delete yvm.fish
- Reload fish shell
- Should see no errors even if yvm is not loaded