### PR TITLE
fix: do not expand variables before calling node script

### DIFF
--- a/fake.js
+++ b/fake.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-process.exit(process.argv[2] !== './*.js')

--- a/fake.js
+++ b/fake.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+process.exit(process.argv[2] !== './*.js')

--- a/src/shell/yvm.sh
+++ b/src/shell/yvm.sh
@@ -61,7 +61,7 @@ yvm() {
     yvm_call_node_script() {
         # do not add anything that outputs stuff to stdout in function, its output is stored in a variable
         export sh_user_paths=$PATH
-        node "${YVM_DIR}/yvm.js" $@
+        node "${YVM_DIR}/yvm.js" "$@"
     }
 
     yvm_init_sh() {
@@ -88,7 +88,7 @@ yvm() {
     elif [ "${command}" = "unload" ]; then
         yvm_unload
     else
-        yvm_call_node_script $@
+        yvm_call_node_script "$@"
     fi
 }
 

--- a/test/scripts/yvm.test.fish
+++ b/test/scripts/yvm.test.fish
@@ -58,6 +58,19 @@ else
     fail $test1_output
 end
 
+testing "yvm exec passes orignal arguments"
+echo "#!/usr/bin/env node
+
+process.exit(process.argv[2] !== './*.js')" > "./fake.js"
+chmod +x "./fake.js"
+ln -sf (pwd)"/fake.js" "node_modules/.bin/fake"
+yvm exec fake './*.js'
+pass
+
+testing "yarn shim passes original arguments"
+yarn fake './*.js'
+pass
+
 testing "yarn shimmed config"
 set test_shim_config_output (yarn --version)
 if test "$test_shim_config_output" = "1.22.5"

--- a/test/scripts/yvm.test.sh
+++ b/test/scripts/yvm.test.sh
@@ -58,6 +58,19 @@ else
     fail ${test1_output}
 fi
 
+testing "yvm exec passes orignal arguments"
+echo "#!/usr/bin/env node
+
+process.exit(process.argv[2] !== './*.js')" > "./fake.js"
+chmod +x "./fake.js"
+ln -sf "$(pwd)/fake.js" "node_modules/.bin/fake"
+yvm exec fake './*.js'
+pass
+
+testing "yarn shim passes original arguments"
+yarn fake './*.js'
+pass
+
 testing "yarn shimmed config"
 test_shim_config_output=$(yarn --version)
 if [[ ${test_shim_config_output} == "1.22.5" ]]; then


### PR DESCRIPTION
## Description

Fixes #756

### Checklist
- [x] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

### DevQA Prep

```bash
make install-watch
```

### DevQA Steps

```bash
$ echo "#!/usr/bin/env node\n\nconsole.log(process.argv)" > "./fake.js"
$ chmod +x "./fake.js"
$ yvm exec fake '*.js'
yarn run v1.22.5
$ /workspace/yvm/node_modules/.bin/fake '*.js'
[
  '/home/gitpod/.nvm/versions/node/v12.18.3/bin/node',
  '/workspace/yvm/node_modules/.bin/fake',
  '*.js'
]
Done in 0.18s.
```

### Comments

This is likely a breaking change
