### PR TITLE
fix: exception when reading yvm config fails, close #926

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ install: build-production install-local
 
 .PHONY: install-watch
 install-watch: node_modules clean_webpack_build
-	$(WEBPACK_BUILD_DEV_WATCH) --env.INSTALL=true
+	$(WEBPACK_BUILD_DEV_WATCH) --env INSTALL=true
 
 # -------------- Linting --------------
 

--- a/src/shell/yvm.fish
+++ b/src/shell/yvm.fish
@@ -18,7 +18,7 @@ function yvm
         end
         if [ -z "$NEW_FISH_USER_PATHS" ]
             yvm_err "Could not get new path from yvm"
-            exit 1
+            return 1
         else
             yvm_set_fish_user_paths $NEW_FISH_USER_PATHS
             set -l new_version (yarn --version)
@@ -36,7 +36,7 @@ function yvm
         end
         if [ -z "$NEW_FISH_USER_PATHS" ]
             yvm_err "Could not remove yvm from system path"
-            exit 1
+            return 1
         else
             yvm_set_fish_user_paths $NEW_FISH_USER_PATHS
         end
@@ -76,7 +76,7 @@ function yvm
         if not type -q "node"
             yvm_err "%s\n" "YVM Could not automatically set yarn version."
             yvm_err "%s\n" "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your fish config file"
-            exit 1
+            return 1
         end
         yvm_shim
     end

--- a/src/shell/yvm.sh
+++ b/src/shell/yvm.sh
@@ -13,7 +13,7 @@ yvm() {
         NEW_PATH=$(yvm_call_node_script get-new-path ${PROVIDED_VERSION})
         if [ -z "${NEW_PATH}" ]; then
             yvm_err "Could not get new path from yvm"
-            exit 1
+            return 1
         else
             yvm_set_user_path $NEW_PATH
             yvm_echo "Now using yarn version $(yarn --version)"
@@ -28,7 +28,7 @@ yvm() {
         NEW_PATH=$(yvm_call_node_script get-old-path)
         if [ -z "${NEW_PATH}" ]; then
             yvm_err "Could not remove yvm from system path"
-            exit 1
+            return 1
         else
             yvm_set_user_path $NEW_PATH
         fi
@@ -68,7 +68,7 @@ yvm() {
         if ! type "node" >/dev/null; then
             yvm_err "YVM Could not find node executable."
             yvm_err "Please ensure your YVM env variables and sourcing are set below sourcing node/nvm in your .zshrc or .bashrc"
-            exit 1
+            return 1
         fi
         yvm_shim
     }

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -117,8 +117,7 @@ export const getRcFileVersion = () => {
         return String(result.config)
     } catch (error) {
         log.error('An error occurred trying to read the version file.')
-        log.info(error)
-        return null
+        throw error
     }
 }
 

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -108,12 +108,18 @@ export const getRcFileVersion = () => {
             '.yarnversion',
         ],
     })
-    const result = explorer.search()
-    if (!result || result.isEmpty || !result.config) {
+    try {
+        const result = explorer.search()
+        if (!result || result.isEmpty || !result.config) {
+            return null
+        }
+        log.info(`Found config ${result.filepath}`)
+        return String(result.config)
+    } catch (error) {
+        log.error('An error occurred trying to read the version file.')
+        log.info(error)
         return null
     }
-    log.info(`Found config ${result.filepath}`)
-    return String(result.config)
 }
 
 export const getVersionInUse = memoize(async () => {

--- a/test/util/version.test.js
+++ b/test/util/version.test.js
@@ -140,13 +140,12 @@ describe('yvm config version', () => {
             })}`,
         })
 
-        const [version2] = await getSplitVersionAndArgs().catch(() => {})
+        await getSplitVersionAndArgs().catch(() => {})
         expect(log.error).toHaveBeenCalledWith(
             expect.stringContaining(
                 'An error occurred trying to read the version file.',
             ),
         )
-        expect(version2).toEqual(mockVersion)
     })
     it('Uses default version when no config available', async () => {
         const mockVersion = '1.9.2'

--- a/test/util/version.test.js
+++ b/test/util/version.test.js
@@ -116,6 +116,38 @@ describe('yvm config version', () => {
             expect.stringContaining('Unable to resolve'),
         )
     })
+    it('Logs error when version discovery fails', async () => {
+        const mockVersion = '1.9.2'
+        vol.fromJSON({ [yvmPath]: {} })
+        await setDefaultVersion({
+            version: mockVersion,
+        })
+
+        jest.spyOn(log, 'error')
+        vol.fromJSON({
+            'package.json': JSON.stringify({
+                engines: { yarn: 'v1.0.0' },
+            }),
+        })
+
+        const [version1] = await getSplitVersionAndArgs()
+        expect(log.error).not.toBeCalled()
+        expect(version1).toEqual('1.0.0')
+
+        vol.fromJSON({
+            'package.json': `corrupted prefix${JSON.stringify({
+                engines: { yarn: 'v1.0.0' },
+            })}`,
+        })
+
+        const [version2] = await getSplitVersionAndArgs().catch(() => {})
+        expect(log.error).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'An error occurred trying to read the version file.',
+            ),
+        )
+        expect(version2).toEqual(mockVersion)
+    })
     it('Uses default version when no config available', async () => {
         const mockVersion = '1.9.2'
         vol.fromJSON({ [yvmPath]: {} })


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->

- If discovering the config file fails, print error.
- If yvm command fails set exit code rather than exit.

### Checklist
- [x] This PR has updated documentation
- [x] This PR has sufficient testing

## Steps To Reproduce

Prior to this PR: Create a directory with a package.json file that has invalid JSON. Run `yvm use`. The shell will exit.

After this PR: Repeat above, and shell will set exit code rather than exit.

### Comments

I believe the shell function also needs some error handling.
